### PR TITLE
Feature/api licencies

### DIFF
--- a/app/Console/Commands/RunScheduledLicenseImport.php
+++ b/app/Console/Commands/RunScheduledLicenseImport.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\LicenseImport\Reporting\TelematBatchReportBuilder;
+use App\Models\LicenseImportBatch;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+
+final class RunScheduledLicenseImport extends Command
+{
+    protected $signature = 'license-import:scheduled-run';
+    protected $description = 'Run the license import and write a TXT report on disk';
+
+    public function __construct(
+        private readonly TelematBatchReportBuilder $reportBuilder,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $startedAt = now();
+
+        $this->info('Starting scheduled license import...');
+
+        $exitCode = Artisan::call('license-import:run');
+        $commandOutput = Artisan::output();
+
+        $batch = LicenseImportBatch::query()->latest('id')->first();
+
+        $reportPath = storage_path('app/license-import');
+        File::ensureDirectoryExists($reportPath);
+
+        $timestamp = now()->format('Y-m-d_H-i-s');
+        $file = $reportPath . "/license-import-report-{$timestamp}.txt";
+
+        $content = [];
+        $content[] = 'LICENSE IMPORT REPORT';
+        $content[] = '=====================';
+        $content[] = '';
+        $content[] = 'Started at: ' . $startedAt->toDateTimeString();
+        $content[] = 'Finished at: ' . now()->toDateTimeString();
+        $content[] = 'Command exit code: ' . $exitCode;
+        $content[] = '';
+
+        if ($batch === null) {
+            $content[] = 'No batch found after command execution.';
+            $content[] = '';
+            $content[] = 'Raw command output:';
+            $content[] = $commandOutput;
+
+            File::put($file, implode(PHP_EOL, $content));
+
+            $this->error("No batch found. TXT report written to: {$file}");
+
+            return self::FAILURE;
+        }
+
+        $report = $this->reportBuilder->build($batch);
+
+        $projection = $report['projection'] ?? [];
+        $validation = $report['validation'] ?? [];
+        $result = $report['result'] ?? [];
+        $issues = $report['issues'] ?? [];
+        $execution = $report['execution'] ?? [];
+        $batchData = $report['batch'] ?? [];
+
+        $content[] = 'Batch';
+        $content[] = '-----';
+        $content[] = 'Batch ID: ' . ($batchData['id'] ?? 'n/a');
+        $content[] = 'Source: ' . ($batchData['source'] ?? 'n/a');
+        $content[] = 'Status: ' . ($batchData['status'] ?? 'n/a');
+        $content[] = 'Active: ' . $this->boolToText($batchData['is_active'] ?? false);
+        $content[] = '';
+
+        $content[] = 'Execution';
+        $content[] = '---------';
+        $content[] = 'Result: ' . ($execution['result'] ?? 'n/a');
+        $content[] = 'Final outcome: ' . ($execution['final_outcome'] ?? 'n/a');
+        $content[] = '';
+
+        $content[] = 'Validation';
+        $content[] = '----------';
+        $content[] = 'Raw rows: ' . ($validation['raw_rows_count'] ?? 0);
+        $content[] = 'Valid rows: ' . ($validation['valid_rows_count'] ?? 0);
+        $content[] = 'Invalid rows: ' . ($validation['invalid_rows_count'] ?? 0);
+        $content[] = 'Error count: ' . ($validation['error_count'] ?? 0);
+        $content[] = 'Warning count: ' . ($validation['warning_count'] ?? 0);
+        $content[] = '';
+
+        $content[] = 'Projection';
+        $content[] = '----------';
+        $content[] = 'Executed: ' . $this->boolToText($projection['executed'] ?? false);
+        $content[] = 'Failed: ' . $this->boolToText($projection['failed'] ?? false);
+        $content[] = 'Strategy: ' . ($projection['strategy'] ?? 'n/a');
+        $content[] = 'Reason: ' . ($projection['reason'] ?? 'n/a');
+        $content[] = 'Inserted: ' . ($projection['inserted_count'] ?? 0);
+        $content[] = 'Updated: ' . ($projection['updated_count'] ?? 0);
+        $content[] = 'Deleted: ' . ($projection['deleted_count'] ?? 0);
+        $content[] = 'Unchanged: ' . ($projection['unchanged_count'] ?? 0);
+        $content[] = 'No-op: ' . $this->boolToText($projection['no_op'] ?? false);
+        $content[] = '';
+
+        $content[] = 'Database update status';
+        $content[] = '----------------------';
+        $dbWasUpdated =
+            (($projection['inserted_count'] ?? 0) > 0)
+            || (($projection['updated_count'] ?? 0) > 0)
+            || (($projection['deleted_count'] ?? 0) > 0);
+
+        $content[] = 'Database changed: ' . $this->boolToText($dbWasUpdated);
+        $content[] = '';
+
+        $content[] = 'Issues';
+        $content[] = '------';
+
+        $issueItems = $issues['items'] ?? [];
+
+        if ($issueItems === []) {
+            $content[] = 'No issues reported.';
+        } else {
+            foreach ($issueItems as $index => $issue) {
+                $content[] = sprintf(
+                    '%d. [%s] %s',
+                    $index + 1,
+                    $issue['level'] ?? 'unknown',
+                    $issue['message'] ?? 'No message'
+                );
+            }
+        }
+
+        $content[] = '';
+        $content[] = 'Command output';
+        $content[] = '--------------';
+        $content[] = trim($commandOutput) !== '' ? trim($commandOutput) : 'No console output.';
+        $content[] = '';
+
+        File::put($file, implode(PHP_EOL, $content));
+
+        $this->info("TXT report written to: {$file}");
+
+        return $exitCode === 0 ? self::SUCCESS : self::FAILURE;
+    }
+
+    private function boolToText(bool $value): string
+    {
+        return $value ? 'yes' : 'no';
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -15,6 +15,11 @@ class Kernel extends ConsoleKernel
         // $schedule->command('inspire')->hourly();
         // Génère chaque nuit à 03:10 (à adapter)
         $schedule->command('sitemap:generate')->dailyAt('15:19');
+
+        $schedule->command('license-import:scheduled-run')
+            ->everyTenMinutes()
+            ->withoutOverlapping()
+            ->appendOutputTo(storage_path('logs/license-import-scheduler.log'));
     }
 
     /**

--- a/app/Domain/LicenseImport/Projection/Strategies/TelematFullReplaceProjectionStrategy.php
+++ b/app/Domain/LicenseImport/Projection/Strategies/TelematFullReplaceProjectionStrategy.php
@@ -45,6 +45,16 @@ final class TelematFullReplaceProjectionStrategy implements TelematProjectionStr
 
                 DB::table('licencies')->delete();
 
+                $driver = DB::getDriverName();
+
+                if ($driver === 'mysql') {
+                    DB::statement('ALTER TABLE licencies AUTO_INCREMENT = 1');
+                }
+
+                if ($driver === 'sqlite') {
+                    DB::statement("DELETE FROM sqlite_sequence WHERE name = 'licencies'");
+                }
+
                 if ($rows !== []) {
                     DB::table('licencies')->insert($rows);
                 }

--- a/app/Models/ClubMatchingRule.php
+++ b/app/Models/ClubMatchingRule.php
@@ -8,4 +8,17 @@ use Illuminate\Database\Eloquent\Model;
 class ClubMatchingRule extends Model
 {
     use HasFactory;
+    protected $table = 'club_matching_rules';
+
+    protected $fillable = [
+        'club_reference_name',
+        'matching_mode',
+        'matching_value',
+        'is_active',
+    ];
+
+    protected $casts = [
+        'is_active' => 'boolean',
+    ];
+
 }

--- a/app/Models/ClubMatchingRule.php
+++ b/app/Models/ClubMatchingRule.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ClubMatchingRule extends Model
+{
+    use HasFactory;
+}

--- a/app/Models/CueScorePlayerMapping.php
+++ b/app/Models/CueScorePlayerMapping.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class CueScorePlayerMapping extends Model
+{
+    use HasFactory;
+}

--- a/app/Models/CueScorePlayerMapping.php
+++ b/app/Models/CueScorePlayerMapping.php
@@ -8,4 +8,28 @@ use Illuminate\Database\Eloquent\Model;
 class CueScorePlayerMapping extends Model
 {
     use HasFactory;
+
+    protected $table = 'cuescore_player_mappings';
+
+    protected $fillable = [
+        'cuescore_participant_id',
+        'cuescore_name',
+        'cuescore_url',
+        'licencie_id',
+        'matching_method',
+        'confidence_score',
+        'is_confirmed',
+        'notes',
+    ];
+
+    protected $casts = [
+        'is_confirmed' => 'boolean',
+    ];
+
+    public function licencie()
+    {
+        return $this->belongsTo(Licencies::class, 'licencie_id');
+    }
+
+
 }

--- a/app/Models/CueScorePlayerMapping.php
+++ b/app/Models/CueScorePlayerMapping.php
@@ -22,10 +22,12 @@ class CueScorePlayerMapping extends Model
         'notes',
     ];
 
+    // Note: 'is_confirmed' est casté en boolean pour faciliter les requêtes et les manipulations de données
     protected $casts = [
         'is_confirmed' => 'boolean',
     ];
 
+    // Relation avec la table des licencies pour accéder aux informations du licencié associé à ce mapping
     public function licencie()
     {
         return $this->belongsTo(Licencies::class, 'licencie_id');

--- a/app/Models/CueScoreRanking.php
+++ b/app/Models/CueScoreRanking.php
@@ -8,4 +8,36 @@ use Illuminate\Database\Eloquent\Model;
 class CueScoreRanking extends Model
 {
     use HasFactory;
+
+    protected $table = 'cuescore_rankings';
+
+    protected $fillable = [
+        'name',
+        'cuescore_id',
+        'url',
+        'source_type',
+        'discipline',
+        'scope',
+        'ranking_type',
+        'team_category',
+        'season',
+        'is_active',
+        'sort_order',
+    ];
+
+    protected $casts = [
+        'is_active' => 'boolean',
+    ];
+
+    public function entries()
+    {
+        return $this->hasMany(CueScoreRankingEntry::class, 'cuescore_ranking_id');
+    }
+
+    public function fetches()
+    {
+        return $this->hasMany(CueScoreRankingFetch::class, 'cuescore_ranking_id');
+    }
+
+
 }

--- a/app/Models/CueScoreRanking.php
+++ b/app/Models/CueScoreRanking.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class CueScoreRanking extends Model
+{
+    use HasFactory;
+}

--- a/app/Models/CueScoreRanking.php
+++ b/app/Models/CueScoreRanking.php
@@ -25,15 +25,18 @@ class CueScoreRanking extends Model
         'sort_order',
     ];
 
+    // Note: 'is_active' est déjà défini dans $fillable, mais il est également important de le caster en boolean pour s'assurer que les valeurs sont correctement interprétées lors de l'accès à cet attribut.
     protected $casts = [
         'is_active' => 'boolean',
     ];
 
+    // Relations avec les entrées et les fetches associées à ce ranking
     public function entries()
     {
         return $this->hasMany(CueScoreRankingEntry::class, 'cuescore_ranking_id');
     }
 
+    // Relation avec les fetches associées à ce ranking pour accéder aux différentes tentatives de récupération des données de classement
     public function fetches()
     {
         return $this->hasMany(CueScoreRankingFetch::class, 'cuescore_ranking_id');

--- a/app/Models/CueScoreRankingEntry.php
+++ b/app/Models/CueScoreRankingEntry.php
@@ -8,4 +8,41 @@ use Illuminate\Database\Eloquent\Model;
 class CueScoreRankingEntry extends Model
 {
     use HasFactory;
+
+    protected $table = 'cuescore_ranking_entries';
+
+    protected $fillable = [
+        'cuescore_ranking_id',
+        'cuescore_ranking_fetch_id',
+        'entry_type',
+        'rank_position',
+        'participant_name',
+        'participant_external_id',
+        'participant_url',
+        'team_name',
+        'team_external_id',
+        'team_url',
+        'points',
+        'played',
+        'wins',
+        'losses',
+        'ties',
+        'additional_data',
+    ];
+
+    protected $casts = [
+        'additional_data' => 'array',
+        'points' => 'decimal:2',
+    ];
+
+    public function ranking()
+    {
+        return $this->belongsTo(CueScoreRanking::class, 'cuescore_ranking_id');
+    }
+
+    public function fetch()
+    {
+        return $this->belongsTo(CueScoreRankingFetch::class, 'cuescore_ranking_fetch_id');
+    }
+
 }

--- a/app/Models/CueScoreRankingEntry.php
+++ b/app/Models/CueScoreRankingEntry.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class CueScoreRankingEntry extends Model
+{
+    use HasFactory;
+}

--- a/app/Models/CueScoreRankingEntry.php
+++ b/app/Models/CueScoreRankingEntry.php
@@ -30,16 +30,19 @@ class CueScoreRankingEntry extends Model
         'additional_data',
     ];
 
+    // Note: 'additional_data' est casté en array pour faciliter l'accès aux données supplémentaires stockées au format JSON, et 'points' est casté en decimal pour garantir une manipulation correcte des valeurs numériques avec deux décimales
     protected $casts = [
         'additional_data' => 'array',
         'points' => 'decimal:2',
     ];
 
+    // Relations pour accéder au ranking et au fetch associés à cette entrée de classement
     public function ranking()
     {
         return $this->belongsTo(CueScoreRanking::class, 'cuescore_ranking_id');
     }
 
+    // Relation pour accéder au fetch associé à cette entrée de classement, ce qui permet de retracer l'origine des données de classement et d'analyser les différentes tentatives de récupération des données
     public function fetch()
     {
         return $this->belongsTo(CueScoreRankingFetch::class, 'cuescore_ranking_fetch_id');

--- a/app/Models/CueScoreRankingFetch.php
+++ b/app/Models/CueScoreRankingFetch.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class CueScoreRankingFetch extends Model
+{
+    use HasFactory;
+}

--- a/app/Models/CueScoreRankingFetch.php
+++ b/app/Models/CueScoreRankingFetch.php
@@ -24,16 +24,19 @@ class CueScoreRankingFetch extends Model
         'is_active',
     ];
 
+    // Note: 'fetched_at' est casté en datetime pour faciliter les requêtes basées sur les dates, et 'is_active' est casté en boolean pour une manipulation plus facile des valeurs booléennes.
     protected $casts = [
         'fetched_at' => 'datetime',
         'is_active' => 'boolean',
     ];
 
+    // Relations pour accéder au ranking associé à ce fetch et aux entrées de classement associées à ce fetch, ce qui permet de retracer l'origine des données de classement et d'analyser les différentes tentatives de récupération des données
     public function ranking()
     {
         return $this->belongsTo(CueScoreRanking::class, 'cuescore_ranking_id');
     }
 
+    // Relation pour accéder aux entrées de classement associées à ce fetch, ce qui permet de retracer l'origine des données de classement et d'analyser les différentes tentatives de récupération des données
     public function entries()
     {
         return $this->hasMany(CueScoreRankingEntry::class, 'cuescore_ranking_fetch_id');

--- a/app/Models/CueScoreRankingFetch.php
+++ b/app/Models/CueScoreRankingFetch.php
@@ -8,4 +8,34 @@ use Illuminate\Database\Eloquent\Model;
 class CueScoreRankingFetch extends Model
 {
     use HasFactory;
+
+    protected $table = 'cuescore_ranking_fetches';
+
+    protected $fillable = [
+        'cuescore_ranking_id',
+        'status',
+        'fetched_at',
+        'http_status',
+        'payload_hash',
+        'records_count',
+        'error_code',
+        'error_message',
+        'raw_payload',
+        'is_active',
+    ];
+
+    protected $casts = [
+        'fetched_at' => 'datetime',
+        'is_active' => 'boolean',
+    ];
+
+    public function ranking()
+    {
+        return $this->belongsTo(CueScoreRanking::class, 'cuescore_ranking_id');
+    }
+
+    public function entries()
+    {
+        return $this->hasMany(CueScoreRankingEntry::class, 'cuescore_ranking_fetch_id');
+    }
 }

--- a/app/Models/Licencies.php
+++ b/app/Models/Licencies.php
@@ -11,4 +11,9 @@ final class Licencies extends Model
     protected $table = 'licencies';
 
     protected $guarded = [];
+
+    public function playerMappings()
+    {
+        return $this->hasMany(CueScorePlayerMapping::class, 'licencie_id');
+    }
 }

--- a/database/migrations/cuescore/2026_04_21_120500_create_cuescore_rankings_table.php
+++ b/database/migrations/cuescore/2026_04_21_120500_create_cuescore_rankings_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('cuescore_rankings', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('cuescore_id')->unique();
+            $table->text('url');
+            $table->string('source_type', 30);
+            $table->string('discipline', 50)->index();
+            $table->string('scope', 30)->index();
+            $table->string('ranking_type', 30)->index();
+            $table->string('team_category', 30)->nullable();
+            $table->string('season', 20);
+            $table->boolean('is_active')->default(false)->index();
+            $table->integer('sort_order')->default(0);
+
+            $table->index(['discipline', 'scope', 'ranking_type']);
+
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('cuescore_rankings');
+    }
+};

--- a/database/migrations/cuescore/2026_04_21_124407_create_cuescore_ranking_fetches_table.php
+++ b/database/migrations/cuescore/2026_04_21_124407_create_cuescore_ranking_fetches_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('cuescore_ranking_fetches', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('cuescore_ranking_id')
+                ->constrained('cuescore_rankings')
+                ->onDelete('cascade')->index();
+
+            $table->string('status', 30)->index();
+            $table->timestamp('fetched_at')->nullable()->index();
+            $table->unsignedSmallInteger('http_status')->nullable();
+            $table->string('payload_hash', 64)->nullable();
+            $table->unsignedInteger('records_count')->default(0);
+            $table->string('error_code', 50)->nullable();
+            $table->text('error_message')->nullable();
+            $table->longText('raw_payload')->nullable();
+            $table->boolean('is_active')->default(false)->index();
+
+            $table->index(['cuescore_ranking_id', 'fetched_at']);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('cuescore_ranking_fetches');
+    }
+};

--- a/database/migrations/cuescore/2026_04_21_124913_create_cuescore_ranking_entries_table.php
+++ b/database/migrations/cuescore/2026_04_21_124913_create_cuescore_ranking_entries_table.php
@@ -1,0 +1,57 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('cuescore_ranking_entries', function (Blueprint $table) {
+            $table->id();
+
+            $table->unsignedBigInteger('cuescore_ranking_id');
+            $table->unsignedBigInteger('cuescore_ranking_fetch_id');
+
+            $table->string('entry_type', 30)->index();
+            $table->unsignedInteger('rank_position')->nullable();
+
+            $table->string('participant_name')->nullable();
+            $table->string('participant_external_id')->nullable()->index();
+            $table->text('participant_url')->nullable();
+
+            $table->string('team_name')->nullable();
+            $table->string('team_external_id')->nullable()->index();
+            $table->text('team_url')->nullable();
+
+            $table->decimal('points', 10, 2)->nullable();
+            $table->unsignedInteger('played')->nullable();
+            $table->unsignedInteger('wins')->nullable();
+            $table->unsignedInteger('losses')->nullable();
+            $table->unsignedInteger('ties')->nullable();
+
+            $table->json('additional_data')->nullable();
+
+            $table->index(['cuescore_ranking_id', 'entry_type'], 'cs_entries_ranking_entry_type_idx');
+            $table->index(['cuescore_ranking_fetch_id', 'entry_type'], 'cs_entries_fetch_entry_type_idx');
+
+            $table->foreign('cuescore_ranking_id', 'cs_entries_ranking_fk')
+                ->references('id')
+                ->on('cuescore_rankings')
+                ->cascadeOnDelete();
+
+            $table->foreign('cuescore_ranking_fetch_id', 'cs_entries_fetch_fk')
+                ->references('id')
+                ->on('cuescore_ranking_fetches')
+                ->cascadeOnDelete();
+
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('cuescore_ranking_entries');
+    }
+};

--- a/database/migrations/cuescore/2026_04_21_130927_create_cuescore_player_mappings_table.php
+++ b/database/migrations/cuescore/2026_04_21_130927_create_cuescore_player_mappings_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('cuescore_player_mappings', function (Blueprint $table) {
+            $table->id();
+
+            $table->string('cuescore_participant_id')->unique();
+            $table->string('cuescore_name');
+            $table->string('cuescore_url')->nullable();
+            
+            $table->foreignId('licencie_id')
+                ->constrained('licencies')
+                ->onDelete('cascade');
+
+            $table->string('matching_method', 30)->index();
+            $table->unsignedTinyInteger('confidence_score')->nullable();
+            $table->boolean('is_confirmed')->default(false)->index();
+            $table->text('notes')->nullable();
+            
+            $table->index(['licencie_id', 'is_confirmed']);
+            
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('cuescore_player_mappings');
+    }
+};

--- a/database/migrations/cuescore/2026_04_21_131802_create_club_matching_rules_table.php
+++ b/database/migrations/cuescore/2026_04_21_131802_create_club_matching_rules_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('club_matching_rules', function (Blueprint $table) {
+            $table->id();
+            $table->string('club_reference_name');
+            $table->string('matching_mode', 30)->index();
+            $table->string('matching_value');
+            $table->boolean('is_active')->default(true)->index();
+
+            $table->index(['is_active', 'matching_mode']);
+
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('club_matching_rules');
+    }
+};

--- a/database/seeders/CueScoreRankingSeeder.php
+++ b/database/seeders/CueScoreRankingSeeder.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class CueScoreRankingSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $rankings = [
+
+            /*
+            |--------------------------------------------------------------------------
+            | AMERICAIN
+            |--------------------------------------------------------------------------
+            */
+
+            // NATIONAL
+            [
+                'name' => 'US Demi Finale N1 SUD 2025-2026',
+                'cuescore_id' => 79941976,
+                'url' => 'https://cuescore.com/ranking/US_Demi+Finale+N1+SUD_2025-2026/79941976',
+                'source_type' => 'ranking',
+                'discipline' => 'americain',
+                'scope' => 'national',
+                'ranking_type' => 'individual',
+                'team_category' => null,
+                'season' => '2025-2026',
+                'is_active' => true,
+                'sort_order' => 1,
+            ],
+
+            [
+                'name' => 'US Demi Finale N1 NORD 2025-2026',
+                'cuescore_id' => 79941973,
+                'url' => 'https://cuescore.com/ranking/US_Demi+Finale+N1+NORD_2025-2026/79941973',
+                'source_type' => 'ranking',
+                'discipline' => 'americain',
+                'scope' => 'national',
+                'ranking_type' => 'individual',
+                'team_category' => null,
+                'season' => '2025-2026',
+                'is_active' => true,
+                'sort_order' => 2,
+            ],
+
+            [
+                'name' => 'US Finale France U17 2025-2026',
+                'cuescore_id' => 79880440,
+                'url' => 'https://cuescore.com/ranking/US_finale+de+France+U17+2025-2026/79880440',
+                'source_type' => 'ranking',
+                'discipline' => 'americain',
+                'scope' => 'national',
+                'ranking_type' => 'individual',
+                'team_category' => null,
+                'season' => '2025-2026',
+                'is_active' => true,
+                'sort_order' => 3,
+            ],
+
+            [
+                'name' => 'US Classement TN N1 2025-2026',
+                'cuescore_id' => 66292051,
+                'url' => 'https://cuescore.com/ranking/US_Classement+TN+N1++2025-2026/66292051',
+                'source_type' => 'ranking',
+                'discipline' => 'americain',
+                'scope' => 'national',
+                'ranking_type' => 'individual',
+                'team_category' => null,
+                'season' => '2025-2026',
+                'is_active' => true,
+                'sort_order' => 4,
+            ],
+
+            // REGIONAL
+            [
+                'name' => 'LBCVL Finale Ligue Americain 25-26',
+                'cuescore_id' => 76092814,
+                'url' => 'https://cuescore.com/ranking/LBCVL+FINALE+LIGUE+AMERICAIN+25-26/76092814',
+                'source_type' => 'ranking',
+                'discipline' => 'americain',
+                'scope' => 'regional',
+                'ranking_type' => 'individual',
+                'team_category' => null,
+                'season' => '2025-2026',
+                'is_active' => true,
+                'sort_order' => 10,
+            ],
+
+            /*
+            |--------------------------------------------------------------------------
+            | SNOOKER
+            |--------------------------------------------------------------------------
+            */
+
+            [
+                'name' => 'Snooker Classement Seniors 2025-2026',
+                'cuescore_id' => 67004710,
+                'url' => 'https://cuescore.com/ranking/SNOOKER_Classement+Seniors+2025%252F2026/67004710',
+                'source_type' => 'ranking',
+                'discipline' => 'snooker',
+                'scope' => 'national',
+                'ranking_type' => 'individual',
+                'team_category' => null,
+                'season' => '2025-2026',
+                'is_active' => true,
+                'sort_order' => 20,
+            ],
+
+            /*
+            |--------------------------------------------------------------------------
+            | BLACKBALL - REGIONAL
+            |--------------------------------------------------------------------------
+            */
+
+            [
+                'name' => 'TOP LIGUE 25-26',
+                'cuescore_id' => 67097476,
+                'url' => 'https://cuescore.com/ranking/TOP+LIGUE+25-26/67097476',
+                'source_type' => 'ranking',
+                'discipline' => 'blackball',
+                'scope' => 'regional',
+                'ranking_type' => 'individual',
+                'team_category' => null,
+                'season' => '2025-2026',
+                'is_active' => true,
+                'sort_order' => 30,
+            ],
+
+            [
+                'name' => 'MIXTE 25-26',
+                'cuescore_id' => 67097479,
+                'url' => 'https://cuescore.com/ranking/MIXTE+25-26/67097479',
+                'source_type' => 'ranking',
+                'discipline' => 'blackball',
+                'scope' => 'regional',
+                'ranking_type' => 'individual',
+                'team_category' => null,
+                'season' => '2025-2026',
+                'is_active' => true,
+                'sort_order' => 31,
+            ],
+
+            /*
+            |--------------------------------------------------------------------------
+            | BLACKBALL - EQUIPES
+            |--------------------------------------------------------------------------
+            */
+
+            [
+                'name' => 'BB CVL ÉQUIPE DR3 25-26',
+                'cuescore_id' => 67097614,
+                'url' => 'https://cuescore.com/tournament/BB_CVL+ÉQUIPE+DR3+25-26/67097614',
+                'source_type' => 'tournament',
+                'discipline' => 'blackball',
+                'scope' => 'regional',
+                'ranking_type' => 'team',
+                'team_category' => 'DR3',
+                'season' => '2025-2026',
+                'is_active' => true,
+                'sort_order' => 40,
+            ],
+
+        ];
+
+        DB::table('cuescore_rankings')->truncate(); // Optionnel : vide la table avant d'insérer les nouvelles données
+        DB::table('cuescore_rankings')->insert($rankings);
+    }
+}

--- a/database/seeders/CueScoreRankingSeeder.php
+++ b/database/seeders/CueScoreRankingSeeder.php
@@ -165,7 +165,18 @@ class CueScoreRankingSeeder extends Seeder
 
         ];
 
-        DB::table('cuescore_rankings')->truncate(); // Optionnel : vide la table avant d'insérer les nouvelles données
+        DB::table('cuescore_rankings')->delete(); // Optionnel : vide la table avant d'insérer les nouvelles données
+        
+        $driver = DB::getDriverName();
+
+        if ($driver === 'mysql') {
+            DB::statement('ALTER TABLE cuescore_rankings AUTO_INCREMENT = 1');
+        }
+
+        if ($driver === 'sqlite') {
+            DB::statement("DELETE FROM sqlite_sequence WHERE name = 'cuescore_rankings'");
+        }
+
         DB::table('cuescore_rankings')->insert($rankings);
     }
 }


### PR DESCRIPTION
Cette Pull Request s'inscrit dans la continuité du projet après la mise en place du scraping des licenciés. 
Elle prépare l'intégration de l'API CueScore en mettant en place la structure de données nécessaire côté backend. 

**Ce qui a été fait** 

**Base de données**
* Création des tables : 
   * ``cuescore_rankings``
   * ``cuescore_ranking_fetches``
   * ``cuescore_ranking_entries``
   * ``cuescore_player_mappings``
   * ``club_matching_rules``
* Mise en place des relations : 
   * Historisation des récupérations
   * Lien entre fetchs et données importées
   * Préparation du matching avec les licenciés

**Seeders**
* Ajout du ``CueScoreRankingSeeder``
* Insertion des classements : 
   * Américains (national / régional)
   * Snooker
   * Blackball
   * Classements individuels
   * Classement par équipes (DN / DR)

**Objectif**
Préparer une architecture robuste pour : 
* Interroger l'API CueScore
* Stocker les résultats
* Historiser les appels
* Filtrer les joueurs du club
* Gérer les classements individuels et par équipes

**A venir dans la prochaine étape**
* Implémentation du service d'appel API CueScore
* Parsing des réponses JSON (ranking / tournament)
* Enregistrement dans ``cuescore_ranking_fetches`` et ``entries``
* Mise en place du matching avec la table ``licencies``
* Création des endpoints API JSON

**Remarques**
* Aucun impact sur le frontend pour le moment
* Données utilisées uniquement côté backend
* Structure pensée pour être évolutive (multi-disciplines, multi-saisons)

**Tests**
* Vérification des migrations
* Vérification de l'insertion des données via seeder
* Structure prête pour tests d'intégration futurs

