### PR TITLE
Ajout de l'endpoint Contact pour finaliser les routes API

### DIFF
--- a/app/Http/Controllers/Api/ContactController.php
+++ b/app/Http/Controllers/Api/ContactController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\ContactResource;
+use App\Models\Contact;
+
+class ContactController extends Controller
+{
+    //
+    public function index(){
+
+        $contact = Contact::all();
+    
+        return response()->json([
+            'count' => $contact->count(),
+            'data' => ContactResource::collection($contact),
+            'error' => null,
+        ]);
+    }
+}

--- a/app/Http/Resources/ContactResource.php
+++ b/app/Http/Resources/ContactResource.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class ContactResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'message' => $this->message,
+            'email' => $this->mail,
+            'telephone' => $this->telephone,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Api\CalendarController;
 use App\Http\Controllers\Api\CaramboleSyncController;
+use App\Http\Controllers\Api\ContactController;
 use App\Http\Controllers\Api\CueScoreController;
 use App\Http\Controllers\Api\DocumentController;
 use App\Http\Controllers\Api\LicenciesController;
@@ -86,6 +87,11 @@ Route::prefix('v1')->group(function () {
         Route::get('/', [DocumentController::class, 'index']);
         Route::get('/{discipline}', [DocumentController::class, 'byDiscipline']);
         Route::get('/{discipline}/{id}', [DocumentController::class, 'show']);
+    });
+
+    // Routes pour les contacts
+    Route::prefix('/contact')->group(function () {
+        Route::get('/', [ContactController::class, 'index']);
     });
     
 });


### PR DESCRIPTION
## Objectif

Mise en place d'un endpoint API dédié aux contacts afin d'exposer les données de contact enregistrées en base au format JSON, dans une structure cohérente avec le reste de l'API du projet. 

## Implémentation

### Controller

Création de `ContactController` avec un endpoint : 
* `index()` : récupération de toutes les informations de contact

### Route

```
/api/v1/contact
GET /contact
``` 

### Resource

Création de `ContactResource` pour normaliser les données exposées. 

Champs exposés : 

* `id`
* `message`
* `email` (mappé depuis `mail`)
* `telephone`
* `created_at`
* `updated_at`
 
## Logique métier

* Transformation du champ legacy : 
   * `mail` -> `email`
* Utilisation d'un `Resource` Laravel pour contrôler la sortie JSON
* Lecture seule uniquement

 ## Format JSON

** Exemple : ** `GET /api/v1/contact`

```
{
    "count": 1,
    "data": [
        {
            "id": 1,
            "message": "Une question, une demande, ou simplement envie d'échanger ?\r\nLe Billard Club de Joué-lès-Tours est à votre écoute !\r\nQue vous souhaitiez en savoir plus sur nos activités, assister à un événement, découvrir le billard ou simplement prendre contact, n'hésitez pas à nous écrire via ce formulaire.\r\nNous vous répondrons avec plaisir !",
            "email": "contact@bcj.fr",
            "telephone": "06 25 13 35 66",
            "created_at": null,
            "updated_at": null
        }
    ],
    "error": null
}
```

## Cohérence avec le reste de l'API

* Cet endpoint suit la même convention que les autres déjà exposés : 
* Utilisation des Resources Laravel
* Structure JSON homogène
* API en lecture seule
* Séparation claire entre modèle Eloquent et réponse API

## Bénéfices

* Normalisation des données exposées
* Cohérence globale de l'API
* Simplification de la consommation côté frontend React
* Réduction du couplage direct avec Eloquent

## Notes importantes

* Endpoint actuellement en lecture seule
* La gestion d'écriture reste dans l'administration

