### PR TITLE
regrouperment des routes API pour la page d'accueil

### DIFF
--- a/app/Http/Controllers/Api/PublicController.php
+++ b/app/Http/Controllers/Api/PublicController.php
@@ -4,8 +4,12 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Http\Resources\MenuResource;
+use App\Http\Resources\PartnerResource;
+use App\Http\Resources\PostResource;
 use App\Http\Resources\SiteSettingsResource;
 use App\Models\Menu;
+use App\Models\Partenaire;
+use App\Models\Post;
 use App\Models\SiteSetting;
 use Illuminate\Http\JsonResponse;
 
@@ -14,6 +18,7 @@ class PublicController extends Controller
     public function site(): JsonResponse
     {
         $siteSettings = SiteSetting::query()->first();
+
         $menus = Menu::query()
             ->where('actif', true)
             ->orderBy('nom')
@@ -23,6 +28,42 @@ class PublicController extends Controller
             'data' => [
                 'site_settings' => $siteSettings ? new SiteSettingsResource($siteSettings) : null,
                 'menus' => MenuResource::collection($menus),
+            ],
+            'error' => null,
+        ]);
+    }
+
+    public function home(): JsonResponse
+    {
+        $siteSettings = SiteSetting::query()->first();
+
+        $menus = Menu::query()
+            ->where('actif', true)
+            ->orderBy('id')
+            ->get();
+
+        $partners = Partenaire::query()
+            ->orderBy('id')
+            ->get();
+
+        $featuredPosts = Post::query()
+            ->where('favoris', true)
+            ->orderByDesc('created_at')
+            ->first();
+
+        if (!$featuredPosts) {
+            $featuredPosts = Post::query()
+                ->orderByDesc('created_at')
+                ->first();
+        }
+
+
+        return response()->json([
+            'data' => [
+                'site_settings' => $siteSettings ? new SiteSettingsResource($siteSettings) : null,
+                'menus' => MenuResource::collection($menus),
+                'partners' => PartnerResource::collection($partners),
+                'featured_posts' => $featuredPosts ? new PostResource($featuredPosts) : null,
             ],
             'error' => null,
         ]);

--- a/routes/api.php
+++ b/routes/api.php
@@ -39,6 +39,7 @@ Route::prefix('v1')->group(function () {
     // Route pour les informations publiques du site
     Route::prefix('/public')->group(function () {
         Route::get('/site', [PublicController::class, 'site']);
+        Route::get('/home', [PublicController::class, 'home']);
     });
     // Route pour les partenaires
     Route::get('/partenaires', [PartnerController::class, 'index']);


### PR DESCRIPTION
## Objectif

Mise en place d'un endpoint API public agrégé pour alimenter la page d'accueil du frontend React. 

Cet endpoint centralise dans une seule réponse JSON les données publiques nécessaires au rendu de la homepage : 

* paramètres du site
* menus actifs
* partenaires
* post mis en avant

## Implémentation

### Route

Ajout d'une route publique : 
```
/api/v1/public/home
GET /public/home
```

### Controller

Ajout d'une méthode `home()` dans `PublicController`.

Cette méthode agrège les données provenant de plusieurs domaines métier : 

* `SiteSetting`
* `Menu`
* `Partenaire`
* `Post`

### Ressources utilisées

* `SiteSettingsResource`
* `MenuResource`
* `PartnerResource`
* `PostResource`

## Logique métier

### Site settings

Récupération du premier enregistrement de `site_settings` pour exposer : 

* logo
* bannière
* coordonnées
* réseaux sociaux

### Menus

Récupération des menus actifs uniquement : 

* filtre sur `actif = true`
* tri par `id`

### Partenaires

Récupération de tous les partenaires : 
* tri par `id`

### Post mis en avant

Récupération d'un unique post favori : 
* filtre sur `favoris = true`
* tri par `created_at DESC`
* récupération du premier résultat

Le champ retourné est : 

```
"featured_post": { ... }
```

Afin d'être fidèle au comportement réel de la page d'accueil, qui n'affiche qu'un seul contenu mis en avant. 

## Formati JSON

** Exemple : ** `GET /api/v1/public/home`

```
{
    "data": {
        "site_settings": {
            "id": 1,
            "logo": "img/a97fed9810c39a9270caead79d014450.png",
            "logo_url": "http://localhost:8000/img/a97fed9810c39a9270caead79d014450.png",
            "banniere": "img/fee04cd87ca0f3ab97bbc5a30d47bafd.png",
            "banniere_url": "http://localhost:8000/img/fee04cd87ca0f3ab97bbc5a30d47bafd.png",
            "adresse": "28 Rue Joseph Cugnot, 37300 Joué-Lès-Tours",
            "telephone": null,
            "email": "contact@bcj37.fr",
            "youtube_page": "https://www.youtube.com/@BCJ37",
            "facebook_page": "https://www.facebook.com/profile.php?id=61573797213739&locale=fr_FR",
            "facebook_page_id": "554099791128649",
            "created_at": "2025-05-13T10:22:11.000000Z",
            "updated_at": "2025-08-21T15:12:15.000000Z"
        },
        "menus": [
            {
                "id": 1,
                "name": "club",
                "image": "menu/Image_Leclub_color.png",
                "image_url": "http://localhost:8000/menu/Image_Leclub_color.png",
                "actif": true,
                "created_at": null,
                "updated_at": "2025-05-29T17:06:41.000000Z"
            },
            {
                "id": 2,
                "name": "blackball",
                "image": "menu/Image_Blackball_color.png",
                "image_url": "http://localhost:8000/menu/Image_Blackball_color.png",
                "actif": true,
                "created_at": null,
                "updated_at": "2025-05-29T17:06:39.000000Z"
            },
            {
                "id": 3,
                "name": "carambole",
                "image": "menu/Image_Carambole_color.png",
                "image_url": "http://localhost:8000/menu/Image_Carambole_color.png",
                "actif": true,
                "created_at": null,
                "updated_at": "2025-05-14T07:36:52.000000Z"
            },
            {
                "id": 4,
                "name": "snooker",
                "image": "menu/Image_Snooker_color.png",
                "image_url": "http://localhost:8000/menu/Image_Snooker_color.png",
                "actif": true,
                "created_at": null,
                "updated_at": "2025-05-14T08:18:08.000000Z"
            },
            {
                "id": 5,
                "name": "americain",
                "image": "menu/Image_Americain_color.png",
                "image_url": "http://localhost:8000/menu/Image_Americain_color.png",
                "actif": true,
                "created_at": null,
                "updated_at": "2026-01-10T16:53:05.000000Z"
            }
        ],
        "partners": [
            {
                "id": 1,
                "name": "Tours métropole",
                "logo": "partenaires/37b4f8ae3d9d972bd5bf0d208c9b6db4.png",
                "logo_url": "http://localhost:8000/partenaires/37b4f8ae3d9d972bd5bf0d208c9b6db4.png",
                "website_url": "https://www.tours-metropole.fr",
                "created_at": "2025-05-26T14:21:37.000000Z",
                "updated_at": "2025-12-06T20:52:52.000000Z"
            },
            {
                "id": 3,
                "name": "Joué les Tours",
                "logo": "partenaires/fcdc86350be85448befa128dd97cb678.jpg",
                "logo_url": "http://localhost:8000/partenaires/fcdc86350be85448befa128dd97cb678.jpg",
                "website_url": "https://www.jouelestours.fr",
                "created_at": "2025-05-26T14:31:35.000000Z",
                "updated_at": "2025-12-06T20:55:45.000000Z"
            },
            {
                "id": 4,
                "name": "FF billard LBCVL",
                "logo": "partenaires/2dc778dbe66b410464d2028a657a27a8.png",
                "logo_url": "http://localhost:8000/partenaires/2dc778dbe66b410464d2028a657a27a8.png",
                "website_url": "https://ligue-billard-centre-val-de-loire.fr",
                "created_at": "2025-05-26T14:32:09.000000Z",
                "updated_at": "2025-12-06T20:56:44.000000Z"
            },
            {
                "id": 6,
                "name": "Handi sport",
                "logo": "partenaires/161322e89b4e12b0baed38f5f875fbe4.png",
                "logo_url": "http://localhost:8000/partenaires/161322e89b4e12b0baed38f5f875fbe4.png",
                "website_url": "https://www.handisport.org",
                "created_at": "2025-05-26T14:32:44.000000Z",
                "updated_at": "2025-12-06T20:57:10.000000Z"
            },
            {
                "id": 11,
                "name": "FFSA",
                "logo": "partenaires/75a23ee4123c3eddd989e2b64e391239.png",
                "logo_url": "http://localhost:8000/partenaires/75a23ee4123c3eddd989e2b64e391239.png",
                "website_url": "https://sportadapte.fr",
                "created_at": "2025-08-19T11:30:46.000000Z",
                "updated_at": "2025-12-06T20:58:53.000000Z"
            },
            {
                "id": 12,
                "name": "Bulldog-billard",
                "logo": "partenaires/12e2647c9ac9a25f6f34d4d0217c63ce.png",
                "logo_url": "http://localhost:8000/partenaires/12e2647c9ac9a25f6f34d4d0217c63ce.png",
                "website_url": "https://bulldog-billard.com",
                "created_at": "2025-08-19T11:31:12.000000Z",
                "updated_at": "2025-12-06T20:59:21.000000Z"
            },
            {
                "id": 16,
                "name": "Brit Hotel Joué-lès-Tours",
                "logo": "partenaires/12a05680-30c8-403e-bc59-085f4b8a3d81.webp",
                "logo_url": "http://localhost:8000/partenaires/12a05680-30c8-403e-bc59-085f4b8a3d81.webp",
                "website_url": "https://hotel-tours.brithotel.fr",
                "created_at": "2025-12-05T09:59:48.000000Z",
                "updated_at": "2025-12-06T21:00:00.000000Z"
            },
            {
                "id": 17,
                "name": "Kyriad Joué-Lès-Tours",
                "logo": "partenaires/87d7527e-b0cc-43a8-ab2c-f9b17e9f950a.webp",
                "logo_url": "http://localhost:8000/partenaires/87d7527e-b0cc-43a8-ab2c-f9b17e9f950a.webp",
                "website_url": "https://tours-joue-les-tours.kyriad.com/fr-fr/?sr=SEO_GOOGLE",
                "created_at": "2025-12-05T10:01:52.000000Z",
                "updated_at": "2025-12-06T21:00:47.000000Z"
            }
        ],
        "featured_posts": {
            "id": 112,
            "title": "2026 - Tournoi National n°4 - Villeneuve-sur-Lot",
            "slug": "2026-tournoi-national-n4-villeneuve-sur-lot",
            "excerpt": "&nbsp;Du 31 janvier au 1er février 2026Un week-end intense pour nos joueurs, avec de très beaux résultats à la clé.&nbsp;Blackball MasterVictoire d’Al...",
            "content": "<h5><strong style=\"color: rgb(101, 104, 108);\"><img src=\"https://static.xx.fbcdn.net/images/emoji.php/v9/t7e/1/16/1f4c5.png\" alt=\"📅\" height=\"16\" width=\"16\">&nbsp;<em>Du 31 janvier au 1er février 2026</em></strong></h5><p class=\"ql-indent-1\">Un week-end intense pour nos joueurs, avec de très beaux résultats à la clé.</p><p><br></p><h5><strong class=\"ql-size-large\" style=\"color: rgb(101, 104, 108);\"><img src=\"https://static.xx.fbcdn.net/images/emoji.php/v9/tbe/1/16/1f3c6.png\" alt=\"🏆\" height=\"16\" width=\"16\">&nbsp;Blackball Master</strong></h5><ul><li>Victoire d’Alex Buscetti&nbsp;—&nbsp;<em>sa première, et avec la manière !</em></li></ul><p class=\"ql-indent-2\">Score final :&nbsp;8–4, un match parfaitement maîtrisé. Grâce à cette performance,&nbsp;Alex grimpe à la 3ᵉ place du classement général.</p><ul><li>&nbsp;Christophe Lambert&nbsp;s’arrête en&nbsp;1/2 finale</li><li>&nbsp;Élie Christidis&nbsp;atteint les&nbsp;1/4 de finale</li></ul><p><br></p><h5><strong class=\"ql-size-large\" style=\"color: rgb(101, 104, 108);\"><img src=\"https://static.xx.fbcdn.net/images/emoji.php/v9/te9/1/16/2640.png\" alt=\"♀️\" height=\"16\" width=\"16\">&nbsp;Catégorie Féminine</strong></h5><ul><li>Ophélie Laval&nbsp;réalise un très beau parcours et atteint la&nbsp;finale</li></ul><p class=\"ql-indent-2\">Un jeu solide tout au long du tournoi, mais la victoire lui échappe.</p><p class=\"ql-indent-2\">Elle se positionne désormais&nbsp;5ᵉ au classement général</p><p><br></p><h5><strong class=\"ql-size-large\" style=\"color: rgb(101, 104, 108);\"><img src=\"https://static.xx.fbcdn.net/images/emoji.php/v9/t8d/1/16/1f500.png\" alt=\"🔀\" height=\"16\" width=\"16\">&nbsp;Catégorie Mixte</strong></h5><ul><li>Jérôme L'Anthoen&nbsp;atteint les&nbsp;1/4 de finale&nbsp;après&nbsp;4 matchs remportés.</li></ul><p class=\"ql-indent-2\">Malgré une défaite au 1er tour du tournoi vétéran, il réalise une très belle opération au mixte.</p><p class=\"ql-indent-2\">4ᵉ place au classement général&nbsp;!</p><p><br></p><h5><strong class=\"ql-size-large\" style=\"color: rgb(101, 104, 108);\"><img src=\"https://static.xx.fbcdn.net/images/emoji.php/v9/t8b/1/16/1f465.png\" alt=\"👥\" height=\"16\" width=\"16\">&nbsp;Compétition Équipes – DN1</strong></h5><ul><li><strong>Joué 1</strong></li></ul><p class=\"ql-indent-2\">3 victoires en 3 matchs</p><p class=\"ql-indent-2\">Dernier match remporté avec le&nbsp;point offensif&nbsp;et&nbsp;5 fermes</p><p class=\"ql-indent-2\">Joué 1 conserve sa 2ᵉ place au classement</p><ul><li><strong>Joué 2</strong></li></ul><p class=\"ql-indent-2\">Victoire lors du premier match</p><p class=\"ql-indent-2\">Défaites sur les deux suivants, avec&nbsp;1 point défensif&nbsp;récupéré</p><p class=\"ql-indent-2\">Une journée compliquée qui les fait descendre à la&nbsp;4ᵉ place</p><p class=\"ql-indent-2\"><em>Mais rien n’est joué : la saison continue !</em></p><p><br></p><p><br></p><p>Félicitations à l’ensemble des joueurs pour leur engagement et leurs performances</p>",
            "discipline": "blackball",
            "discipline_id": 1,
            "year": 2026,
            "favoris": true,
            "image": null,
            "image_url": null,
            "video": "https://sportenfrance.com/videos/x9yzs4s",
            "created_at": "2026-02-02T08:11:13.000000Z",
            "updated_at": "2026-02-02T08:31:49.000000Z"
        }
    },
    "error": null
}

```

## Cohérence avec le reste de l'API

Cet endpoint suit le même logique que les autres endpoints déjà mis en place : 
* utilisation des Resources Laravel
* structure JSON normalisée
* séparation entre données brutes et données exposées
* API en lecture seule

## Bénéfices

* un seul appel API pour alimenter la homepage
* simplification du frontend React
* réduction du nombre d'appels réseau
* cohérence avec l'architecture API-first du projet
* meilleure lisibilité fonctionnelle du domaine "public"

## Notes importantes

* Les pages légales ne sont pas incluses dans cette PR
* Elles restent pour le moment servies par des vues Blade
* L'endpoint est strictement aligné avec le contenu actuellement visible sur la page d'accueil
* Pas de `latest_post` exposé, car ce bloc n'est pas présent sur la homepage actuelle. 