### PR TITLE
Feature/api refactor

### DIFF
--- a/app/Http/Controllers/Api/CalendarController.php
+++ b/app/Http/Controllers/Api/CalendarController.php
@@ -18,8 +18,12 @@ class CalendarController extends Controller
             ->get();
 
         return response()->json([
-            'count' => $calendars->count(),
             'data' => CalendarResource::collection($calendars),
+            'meta' => [
+                'count' => $calendars->count(),
+            ],
+            'links' => [],
+            'error' => null,
         ]);
     }
 
@@ -35,9 +39,13 @@ class CalendarController extends Controller
             ->get();
 
         return response()->json([
-            'discipline' => $discipline,
-            'count' => $calendars->count(),
             'data' => CalendarResource::collection($calendars),
+            'meta' => [
+                'discipline' => $discipline,
+                'count' => $calendars->count(),
+            ],
+            'links' => [],
+            'error' => null,
         ]);
     }
 
@@ -54,9 +62,17 @@ class CalendarController extends Controller
             ->firstOrFail();
 
         return response()->json([
-            'calendar' => new CalendarResource($calendar),
-            'count' => $calendar->events->count(),
-            'data' => CalendarEventResource::collection($calendar->events),
+            'data' => [
+                'calendar' => new CalendarResource($calendar),
+                'events' => CalendarEventResource::collection($calendar->events),
+            ],
+            'meta' => [
+                'discipline' => $discipline,
+                'scope' => $scope,
+                'count' => $calendar->events->count(),
+            ],
+            'links' => [],
+            'error' => null,
         ]);
     }
 

--- a/app/Http/Controllers/Api/ContactController.php
+++ b/app/Http/Controllers/Api/ContactController.php
@@ -5,17 +5,20 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\ContactResource;
 use App\Models\Contact;
+use Illuminate\Http\JsonResponse;
 
 class ContactController extends Controller
 {
-    //
-    public function index(){
-
+    public function index(): JsonResponse
+    {
         $contact = Contact::all();
-    
+
         return response()->json([
-            'count' => $contact->count(),
             'data' => ContactResource::collection($contact),
+            'meta' => [
+                'count' => $contact->count(),
+            ],
+            'links' => [],
             'error' => null,
         ]);
     }

--- a/app/Http/Controllers/Api/CueScoreController.php
+++ b/app/Http/Controllers/Api/CueScoreController.php
@@ -3,16 +3,19 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
-use App\Models\ClubMatchingRule;
-use App\Models\CueScorePlayerMapping;
 use App\Models\CueScoreRanking;
+use App\Services\CueScoreClubRankingService;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Collection;
 
 class CueScoreController extends Controller
 {
+    public function __construct(
+        private CueScoreClubRankingService $clubRankingService
+    ) {
+    }
+
     public function index(Request $request): JsonResponse
     {
         $rankings = $this->applyRankingFilters(
@@ -31,7 +34,7 @@ class CueScoreController extends Controller
 
     public function show(CueScoreRanking $ranking): JsonResponse
     {
-        $activeFetch = $this->getActiveFetch($ranking);
+        $activeFetch = $this->clubRankingService->getActiveFetch($ranking);
 
         return response()->json([
             'data' => array_merge(
@@ -45,15 +48,15 @@ class CueScoreController extends Controller
 
     public function club(CueScoreRanking $ranking): JsonResponse
     {
-        $activeFetch = $this->getActiveFetch($ranking);
+        $activeFetch = $this->clubRankingService->getActiveFetch($ranking);
 
         if ($activeFetch === null) {
             return $this->emptyRankingResponse($ranking, 'Aucun fetch actif trouvé pour ce classement.');
         }
 
         $data = $ranking->ranking_type === 'team'
-            ? $this->buildTeamRankingData($ranking, $activeFetch->id)
-            : $this->buildIndividualRankingData($ranking, $activeFetch->id);
+            ? $this->clubRankingService->buildTeamRankingData($ranking, $activeFetch->id)
+            : $this->clubRankingService->buildIndividualRankingData($ranking, $activeFetch->id);
 
         return response()->json([
             'count' => $data['data']->count(),
@@ -67,13 +70,13 @@ class CueScoreController extends Controller
 
     public function teams(CueScoreRanking $ranking): JsonResponse
     {
-        $activeFetch = $this->getActiveFetch($ranking);
+        $activeFetch = $this->clubRankingService->getActiveFetch($ranking);
 
         if ($activeFetch === null) {
             return $this->emptyRankingResponse($ranking, 'Aucun fetch actif trouvé pour ce classement.');
         }
 
-        $data = $this->buildTeamRankingData($ranking, $activeFetch->id);
+        $data = $this->clubRankingService->buildTeamRankingData($ranking, $activeFetch->id);
 
         return response()->json([
             'count' => $data['data']->count(),
@@ -133,14 +136,6 @@ class CueScoreController extends Controller
         return $query;
     }
 
-    private function getActiveFetch(CueScoreRanking $ranking)
-    {
-        return $ranking->fetches()
-            ->where('is_active', true)
-            ->latest('id')
-            ->first();
-    }
-
     private function serializeRanking(CueScoreRanking $ranking): array
     {
         return [
@@ -188,115 +183,6 @@ class CueScoreController extends Controller
         ];
     }
 
-    private function buildIndividualRankingData(CueScoreRanking $ranking, int $fetchId): array
-    {
-        $entries = $ranking->entries()
-            ->where('cuescore_ranking_fetch_id', $fetchId)
-            ->where('entry_type', 'player')
-            ->orderBy('rank_position')
-            ->get();
-
-        $participantIds = $entries
-            ->pluck('participant_external_id')
-            ->filter()
-            ->map(fn ($id) => (string) $id)
-            ->unique()
-            ->values();
-
-        $mappings = CueScorePlayerMapping::query()
-            ->with('licencie')
-            ->whereIn('cuescore_participant_id', $participantIds)
-            ->where('is_confirmed', true)
-            ->get()
-            ->keyBy(fn ($mapping) => (string) $mapping->cuescore_participant_id);
-
-        $data = $entries
-            ->filter(fn ($entry) => $entry->participant_external_id !== null
-                && $mappings->has((string) $entry->participant_external_id))
-            ->map(function ($entry) use ($mappings) {
-                $mapping = $mappings->get((string) $entry->participant_external_id);
-                $licencie = $mapping?->licencie;
-
-                return [
-                    'rank_position' => $entry->rank_position,
-                    'participant_name' => $entry->participant_name,
-                    'participant_external_id' => $entry->participant_external_id,
-                    'participant_url' => $entry->participant_url,
-                    'points' => $entry->points,
-                    'played' => $entry->played,
-                    'wins' => $entry->wins,
-                    'losses' => $entry->losses,
-                    'ties' => $entry->ties,
-                    'matching' => [
-                        'method' => $mapping?->matching_method,
-                        'confidence_score' => $mapping?->confidence_score,
-                        'is_confirmed' => (bool) $mapping?->is_confirmed,
-                    ],
-                    'licencie' => $licencie ? [
-                        'id' => $licencie->id,
-                        'licence' => $licencie->licence ?? null,
-                        'nom' => $licencie->nom ?? null,
-                        'prenom' => $licencie->prenom ?? null,
-                    ] : null,
-                ];
-            })
-            ->values();
-
-        return [
-            'data' => $data,
-            'meta' => [],
-        ];
-    }
-
-    private function buildTeamRankingData(CueScoreRanking $ranking, int $fetchId): array
-    {
-        $entries = $ranking->entries()
-            ->where('cuescore_ranking_fetch_id', $fetchId)
-            ->where('entry_type', 'team')
-            ->orderBy('rank_position')
-            ->get();
-
-        $rules = ClubMatchingRule::query()
-            ->where('is_active', true)
-            ->get();
-
-        $hasClubTeam = $entries->contains(
-            fn ($entry) => $this->teamMatchesClubRules($entry->team_name, $rules)
-        );
-
-        if (! $hasClubTeam) {
-            return [
-                'data' => collect(),
-                'meta' => [
-                    'club_team_present' => false,
-                ],
-            ];
-        }
-
-        $data = $entries->map(function ($entry) use ($rules) {
-            return [
-                'rank_position' => $entry->rank_position,
-                'team_name' => $entry->team_name,
-                'team_external_id' => $entry->team_external_id,
-                'team_url' => $entry->team_url,
-                'points' => $entry->points,
-                'played' => $entry->played,
-                'wins' => $entry->wins,
-                'losses' => $entry->losses,
-                'ties' => $entry->ties,
-                'is_club_team' => $this->teamMatchesClubRules($entry->team_name, $rules),
-                'additional_data' => $entry->additional_data,
-            ];
-        })->values();
-
-        return [
-            'data' => $data,
-            'meta' => [
-                'club_team_present' => true,
-            ],
-        ];
-    }
-
     private function emptyRankingResponse(CueScoreRanking $ranking, string $message): JsonResponse
     {
         return response()->json([
@@ -308,33 +194,6 @@ class CueScoreController extends Controller
                 'message' => $message,
             ],
         ]);
-    }
-
-    private function teamMatchesClubRules(?string $teamName, Collection $rules): bool
-    {
-        $teamName = $this->normalizeClubText($teamName);
-
-        foreach ($rules as $rule) {
-            $value = $this->normalizeClubText((string) $rule->matching_value);
-
-            if ($value === '') {
-                continue;
-            }
-
-            if ($rule->matching_mode === 'contains' && str_contains($teamName, $value)) {
-                return true;
-            }
-
-            if ($rule->matching_mode === 'equals' && $teamName === $value) {
-                return true;
-            }
-
-            if ($rule->matching_mode === 'starts_with' && str_starts_with($teamName, $value)) {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     private function clubOverviewFromFilters(array $filters): JsonResponse
@@ -359,7 +218,7 @@ class CueScoreController extends Controller
         $rankings = $query->get();
 
         $data = $rankings->map(function (CueScoreRanking $ranking) {
-            $activeFetch = $this->getActiveFetch($ranking);
+            $activeFetch = $this->clubRankingService->getActiveFetch($ranking);
 
             if ($activeFetch === null) {
                 return [
@@ -371,8 +230,8 @@ class CueScoreController extends Controller
             }
 
             $rankingData = $ranking->ranking_type === 'team'
-                ? $this->buildTeamRankingData($ranking, $activeFetch->id)
-                : $this->buildIndividualRankingData($ranking, $activeFetch->id);
+                ? $this->clubRankingService->buildTeamRankingData($ranking, $activeFetch->id)
+                : $this->clubRankingService->buildIndividualRankingData($ranking, $activeFetch->id);
 
             return [
                 'ranking' => $this->serializeRanking($ranking),
@@ -388,33 +247,5 @@ class CueScoreController extends Controller
             'filters' => $filters,
             'data' => $data,
         ]);
-    }
-
-    private function normalizeClubText(?string $value): string
-    {
-        if ($value === null) {
-            return '';
-        }
-
-        $value = trim($value);
-        $value = mb_strtolower($value, 'UTF-8');
-
-        $replacements = [
-            'à' => 'a', 'á' => 'a', 'â' => 'a', 'ä' => 'a',
-            'ç' => 'c',
-            'è' => 'e', 'é' => 'e', 'ê' => 'e', 'ë' => 'e',
-            'ì' => 'i', 'í' => 'i', 'î' => 'i', 'ï' => 'i',
-            'ñ' => 'n',
-            'ò' => 'o', 'ó' => 'o', 'ô' => 'o', 'ö' => 'o',
-            'ù' => 'u', 'ú' => 'u', 'û' => 'u', 'ü' => 'u',
-            'ý' => 'y', 'ÿ' => 'y',
-            '\'' => ' ',
-            '-' => ' ',
-        ];
-
-        $value = strtr($value, $replacements);
-        $value = preg_replace('/\s+/', ' ', $value) ?? $value;
-
-        return trim($value);
     }
 }

--- a/app/Http/Controllers/Api/CueScoreController.php
+++ b/app/Http/Controllers/Api/CueScoreController.php
@@ -27,8 +27,12 @@ class CueScoreController extends Controller
         $data = $rankings->map(fn (CueScoreRanking $ranking) => $this->serializeRanking($ranking));
 
         return response()->json([
-            'count' => $data->count(),
             'data' => $data,
+            'meta' => [
+                'count' => $data->count(),
+            ],
+            'links' => [],
+            'error' => null,
         ]);
     }
 
@@ -43,6 +47,9 @@ class CueScoreController extends Controller
                     'active_fetch' => $this->serializeFetch($activeFetch),
                 ]
             ),
+            'meta' => [],
+            'links' => [],
+            'error' => null,
         ]);
     }
 
@@ -54,17 +61,21 @@ class CueScoreController extends Controller
             return $this->emptyRankingResponse($ranking, 'Aucun fetch actif trouvé pour ce classement.');
         }
 
-        $data = $ranking->ranking_type === 'team'
+        $rankingData = $ranking->ranking_type === 'team'
             ? $this->clubRankingService->buildTeamRankingData($ranking, $activeFetch->id)
             : $this->clubRankingService->buildIndividualRankingData($ranking, $activeFetch->id);
 
         return response()->json([
-            'count' => $data['data']->count(),
-            'data' => $data['data']->values(),
+            'data' => $rankingData['data']->values(),
             'meta' => array_merge(
+                [
+                    'count' => $rankingData['data']->count(),
+                ],
                 $this->buildRankingMeta($ranking, $activeFetch->id),
-                $data['meta']
+                $rankingData['meta']
             ),
+            'links' => [],
+            'error' => null,
         ]);
     }
 
@@ -76,15 +87,19 @@ class CueScoreController extends Controller
             return $this->emptyRankingResponse($ranking, 'Aucun fetch actif trouvé pour ce classement.');
         }
 
-        $data = $this->clubRankingService->buildTeamRankingData($ranking, $activeFetch->id);
+        $rankingData = $this->clubRankingService->buildTeamRankingData($ranking, $activeFetch->id);
 
         return response()->json([
-            'count' => $data['data']->count(),
-            'data' => $data['data']->values(),
+            'data' => $rankingData['data']->values(),
             'meta' => array_merge(
+                [
+                    'count' => $rankingData['data']->count(),
+                ],
                 $this->buildRankingMeta($ranking, $activeFetch->id),
-                $data['meta']
+                $rankingData['meta']
             ),
+            'links' => [],
+            'error' => null,
         ]);
     }
 
@@ -186,13 +201,15 @@ class CueScoreController extends Controller
     private function emptyRankingResponse(CueScoreRanking $ranking, string $message): JsonResponse
     {
         return response()->json([
-            'count' => 0,
             'data' => [],
             'meta' => [
+                'count' => 0,
                 'ranking_id' => $ranking->id,
                 'ranking_name' => $ranking->name,
                 'message' => $message,
             ],
+            'links' => [],
+            'error' => null,
         ]);
     }
 
@@ -243,9 +260,13 @@ class CueScoreController extends Controller
         })->values();
 
         return response()->json([
-            'count' => $data->count(),
-            'filters' => $filters,
             'data' => $data,
+            'meta' => [
+                'count' => $data->count(),
+                'filters' => $filters,
+            ],
+            'links' => [],
+            'error' => null,
         ]);
     }
 }

--- a/app/Http/Controllers/Api/DisciplineController.php
+++ b/app/Http/Controllers/Api/DisciplineController.php
@@ -7,26 +7,31 @@ use App\Http\Resources\CalendarEventResource;
 use App\Http\Resources\DocumentResource;
 use App\Http\Resources\PostResource;
 use App\Models\Calendar;
-use App\Models\ClubMatchingRule;
-use App\Models\CueScorePlayerMapping;
 use App\Models\CueScoreRanking;
 use App\Models\Document;
 use App\Models\Post;
+use App\Services\CueScoreClubRankingService;
+use App\Support\DisciplineMapper;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Collection;
 
 class DisciplineController extends Controller
 {
+    public function __construct(
+        private CueScoreClubRankingService $clubRankingService
+    ) {
+    }
+
     public function show(string $discipline): JsonResponse
     {
-        if (!$this->isValidDiscipline($discipline)) {
+        if (!DisciplineMapper::isValidSlug($discipline)) {
             return response()->json([
                 'message' => 'Discipline not found',
                 'error' => 'discipline_not_found',
             ], 404);
         }
 
-        $disciplineId = $this->getDisciplineId($discipline);
+        $disciplineId = DisciplineMapper::idFromSlug($discipline);
 
         $posts = Post::query()
             ->where('discipline', $disciplineId)
@@ -78,7 +83,7 @@ class DisciplineController extends Controller
 
     public function rankingsPreview(string $discipline): JsonResponse
     {
-        if (!$this->isValidDiscipline($discipline)) {
+        if (!DisciplineMapper::isValidSlug($discipline)) {
             return response()->json([
                 'message' => 'Discipline not found',
                 'error' => 'discipline_not_found',
@@ -104,15 +109,19 @@ class DisciplineController extends Controller
 
         $grouped = $rankings
             ->map(function (CueScoreRanking $ranking) {
-                $activeFetch = $this->getActiveFetch($ranking);
+                $activeFetch = $this->clubRankingService->getActiveFetch($ranking);
 
                 if ($activeFetch === null) {
                     return null;
                 }
 
                 $rankingData = $ranking->ranking_type === 'team'
-                    ? $this->buildPreviewTeamRankingData($ranking, $activeFetch->id)
-                    : $this->buildPreviewIndividualRankingData($ranking, $activeFetch->id);
+                    ? $this->clubRankingService->buildTeamRankingData($ranking, $activeFetch->id)
+                    : $this->clubRankingService->buildIndividualRankingData(
+                        $ranking,
+                        $activeFetch->id,
+                        $this->getPreviewLimit()
+                    );
 
                 if ($rankingData['data']->isEmpty()) {
                     return null;
@@ -154,189 +163,6 @@ class DisciplineController extends Controller
         ]);
     }
 
-    private function buildPreviewIndividualRankingData(CueScoreRanking $ranking, int $fetchId): array
-    {
-        $entries = $ranking->entries()
-            ->where('cuescore_ranking_fetch_id', $fetchId)
-            ->where('entry_type', 'player')
-            ->orderBy('rank_position')
-            ->get();
-
-        $participantIds = $entries
-            ->pluck('participant_external_id')
-            ->filter()
-            ->map(fn ($id) => (string) $id)
-            ->unique()
-            ->values();
-
-        $mappings = CueScorePlayerMapping::query()
-            ->with('licencie')
-            ->whereIn('cuescore_participant_id', $participantIds)
-            ->where('is_confirmed', true)
-            ->get()
-            ->keyBy(fn ($mapping) => (string) $mapping->cuescore_participant_id);
-
-        $data = $entries
-            ->filter(fn ($entry) => $entry->participant_external_id !== null
-                && $mappings->has((string) $entry->participant_external_id))
-            ->take($this->getPreviewLimit())
-            ->map(function ($entry) use ($mappings) {
-                $mapping = $mappings->get((string) $entry->participant_external_id);
-                $licencie = $mapping?->licencie;
-
-                return [
-                    'rank_position' => $entry->rank_position,
-                    'participant_name' => $entry->participant_name,
-                    'participant_external_id' => $entry->participant_external_id,
-                    'participant_url' => $entry->participant_url,
-                    'points' => $entry->points,
-                    'played' => $entry->played,
-                    'wins' => $entry->wins,
-                    'losses' => $entry->losses,
-                    'ties' => $entry->ties,
-                    'matching' => [
-                        'method' => $mapping?->matching_method,
-                        'confidence_score' => $mapping?->confidence_score,
-                        'is_confirmed' => (bool) $mapping?->is_confirmed,
-                    ],
-                    'licencie' => $licencie ? [
-                        'id' => $licencie->id,
-                        'licence' => $licencie->licence ?? null,
-                        'nom' => $licencie->nom ?? null,
-                        'prenom' => $licencie->prenom ?? null,
-                    ] : null,
-                ];
-            })
-            ->values();
-
-        return [
-            'data' => $data,
-            'meta' => [],
-        ];
-    }
-
-    private function buildPreviewTeamRankingData(CueScoreRanking $ranking, int $fetchId): array
-    {
-        $entries = $ranking->entries()
-            ->where('cuescore_ranking_fetch_id', $fetchId)
-            ->where('entry_type', 'team')
-            ->orderBy('rank_position')
-            ->get();
-
-        $rules = ClubMatchingRule::query()
-            ->where('is_active', true)
-            ->get();
-
-        $hasClubTeam = $entries->contains(
-            fn ($entry) => $this->teamMatchesClubRules($entry->team_name, $rules)
-        );
-
-        if (! $hasClubTeam) {
-            return [
-                'data' => collect(),
-                'meta' => [
-                    'club_team_present' => false,
-                ],
-            ];
-        }
-
-        $data = $entries->map(function ($entry) use ($rules) {
-            return [
-                'rank_position' => $entry->rank_position,
-                'team_name' => $entry->team_name,
-                'team_external_id' => $entry->team_external_id,
-                'team_url' => $entry->team_url,
-                'points' => $entry->points,
-                'played' => $entry->played,
-                'wins' => $entry->wins,
-                'losses' => $entry->losses,
-                'ties' => $entry->ties,
-                'is_club_team' => $this->teamMatchesClubRules($entry->team_name, $rules),
-                'additional_data' => $entry->additional_data,
-            ];
-        })->values();
-
-        return [
-            'data' => $data,
-            'meta' => [
-                'club_team_present' => true,
-            ],
-        ];
-    }
-
-    private function getActiveFetch(CueScoreRanking $ranking)
-    {
-        return $ranking->fetches()
-            ->where('is_active', true)
-            ->latest('id')
-            ->first();
-    }
-
-    private function teamMatchesClubRules(?string $teamName, Collection $rules): bool
-    {
-        $teamName = $this->normalizeClubText($teamName);
-
-        foreach ($rules as $rule) {
-            $value = $this->normalizeClubText((string) $rule->matching_value);
-
-            if ($value === '') {
-                continue;
-            }
-
-            if ($rule->matching_mode === 'contains' && str_contains($teamName, $value)) {
-                return true;
-            }
-
-            if ($rule->matching_mode === 'equals' && $teamName === $value) {
-                return true;
-            }
-
-            if ($rule->matching_mode === 'starts_with' && str_starts_with($teamName, $value)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private function normalizeClubText(?string $value): string
-    {
-        if ($value === null) {
-            return '';
-        }
-
-        $value = trim($value);
-        $value = mb_strtolower($value, 'UTF-8');
-
-        $replacements = [
-            'à' => 'a', 'á' => 'a', 'â' => 'a', 'ä' => 'a',
-            'ç' => 'c',
-            'è' => 'e', 'é' => 'e', 'ê' => 'e', 'ë' => 'e',
-            'ì' => 'i', 'í' => 'i', 'î' => 'i', 'ï' => 'i',
-            'ñ' => 'n',
-            'ò' => 'o', 'ó' => 'o', 'ô' => 'o', 'ö' => 'o',
-            'ù' => 'u', 'ú' => 'u', 'û' => 'u', 'ü' => 'u',
-            'ý' => 'y', 'ÿ' => 'y',
-            '\'' => ' ',
-            '-' => ' ',
-        ];
-
-        $value = strtr($value, $replacements);
-        $value = preg_replace('/\s+/', ' ', $value) ?? $value;
-
-        return trim($value);
-    }
-
-    private function isValidDiscipline(string $discipline): bool
-    {
-        return in_array($discipline, [
-            'blackball',
-            'carambole',
-            'snooker',
-            'americain',
-        ], true);
-    }
-
     private function getPreviewLimit(): int
     {
         $limit = (int) request('limit', 5);
@@ -346,17 +172,5 @@ class DisciplineController extends Controller
         }
 
         return min($limit, 10);
-    }
-
-    private function getDisciplineId(string $discipline): ?int
-    {
-        $mapping = [
-            'blackball' => 1,
-            'carambole' => 2,
-            'snooker' => 3,
-            'americain' => 4,
-        ];
-
-        return $mapping[$discipline] ?? null;
     }
 }

--- a/app/Http/Controllers/Api/DisciplineController.php
+++ b/app/Http/Controllers/Api/DisciplineController.php
@@ -25,10 +25,7 @@ class DisciplineController extends Controller
     public function show(string $discipline): JsonResponse
     {
         if (!DisciplineMapper::isValidSlug($discipline)) {
-            return response()->json([
-                'message' => 'Discipline not found',
-                'error' => 'discipline_not_found',
-            ], 404);
+            return $this->disciplineNotFoundResponse();
         }
 
         $disciplineId = DisciplineMapper::idFromSlug($discipline);
@@ -64,7 +61,6 @@ class DisciplineController extends Controller
         }
 
         return response()->json([
-            'discipline' => $discipline,
             'data' => [
                 'posts' => PostResource::collection($posts),
                 'calendar' => CalendarEventResource::collection($calendarEvents),
@@ -72,11 +68,13 @@ class DisciplineController extends Controller
                 'rankings' => $rankings,
             ],
             'meta' => [
+                'discipline' => $discipline,
                 'posts_count' => $posts->count(),
                 'calendar_count' => $calendarEvents->count(),
                 'documents_count' => $documents->count(),
                 'rankings_count' => $rankings === null ? null : $rankings->count(),
             ],
+            'links' => [],
             'error' => null,
         ]);
     }
@@ -84,16 +82,17 @@ class DisciplineController extends Controller
     public function rankingsPreview(string $discipline): JsonResponse
     {
         if (!DisciplineMapper::isValidSlug($discipline)) {
-            return response()->json([
-                'message' => 'Discipline not found',
-                'error' => 'discipline_not_found',
-            ], 404);
+            return $this->disciplineNotFoundResponse();
         }
 
         if ($discipline === 'carambole') {
             return response()->json([
-                'discipline' => $discipline,
                 'data' => null,
+                'meta' => [
+                    'discipline' => $discipline,
+                    'rankings_supported' => false,
+                ],
+                'links' => [],
                 'error' => null,
             ]);
         }
@@ -157,8 +156,14 @@ class DisciplineController extends Controller
             });
 
         return response()->json([
-            'discipline' => $discipline,
             'data' => $grouped,
+            'meta' => [
+                'discipline' => $discipline,
+                'count' => $grouped->flatten(1)->count(),
+                'limit' => $this->getPreviewLimit(),
+                'rankings_supported' => true,
+            ],
+            'links' => [],
             'error' => null,
         ]);
     }
@@ -172,5 +177,18 @@ class DisciplineController extends Controller
         }
 
         return min($limit, 10);
+    }
+
+    private function disciplineNotFoundResponse(): JsonResponse
+    {
+        return response()->json([
+            'data' => null,
+            'meta' => [],
+            'links' => [],
+            'error' => [
+                'code' => 'discipline_not_found',
+                'message' => 'Discipline not found',
+            ],
+        ], 404);
     }
 }

--- a/app/Http/Controllers/Api/DocumentController.php
+++ b/app/Http/Controllers/Api/DocumentController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\Document;
 use App\Http\Resources\DocumentResource;
 use Illuminate\Http\JsonResponse;
+use App\Support\DisciplineMapper;
 
 class DocumentController extends Controller
 {
@@ -22,7 +23,7 @@ class DocumentController extends Controller
 
     public function byDiscipline(string $discipline): JsonResponse
     {
-        $disciplineId = $this->getDisciplineId($discipline);
+        $disciplineId = DisciplineMapper::idFromSlug($discipline);
 
         if ($disciplineId === null) {
             return response()->json([
@@ -45,7 +46,7 @@ class DocumentController extends Controller
 
     public function show(string $discipline, int $id): JsonResponse
     {
-        $disciplineId = $this->getDisciplineId($discipline);
+        $disciplineId = DisciplineMapper::idFromSlug($discipline);
 
         if ($disciplineId === null) {
             return response()->json([
@@ -71,17 +72,5 @@ class DocumentController extends Controller
             'data' => new DocumentResource($document),
             'error' => null,
         ]);
-    }
-
-    private function getDisciplineId(string $discipline): ?int
-    {
-        $mapping = [
-            'blackball' => 1,
-            'carambole' => 2,
-            'snooker' => 3,
-            'americain' => 4,
-        ];
-
-        return $mapping[$discipline] ?? null;
     }
 }

--- a/app/Http/Controllers/Api/DocumentController.php
+++ b/app/Http/Controllers/Api/DocumentController.php
@@ -3,10 +3,10 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
-use App\Models\Document;
 use App\Http\Resources\DocumentResource;
-use Illuminate\Http\JsonResponse;
+use App\Models\Document;
 use App\Support\DisciplineMapper;
+use Illuminate\Http\JsonResponse;
 
 class DocumentController extends Controller
 {
@@ -15,8 +15,11 @@ class DocumentController extends Controller
         $documents = Document::query()->get();
 
         return response()->json([
-            'count' => $documents->count(),
             'data' => DocumentResource::collection($documents),
+            'meta' => [
+                'count' => $documents->count(),
+            ],
+            'links' => [],
             'error' => null,
         ]);
     }
@@ -26,10 +29,7 @@ class DocumentController extends Controller
         $disciplineId = DisciplineMapper::idFromSlug($discipline);
 
         if ($disciplineId === null) {
-            return response()->json([
-                'message' => 'Discipline not found',
-                'error' => 'discipline_not_found',
-            ], 404);
+            return $this->disciplineNotFoundResponse();
         }
 
         $documents = Document::query()
@@ -37,9 +37,12 @@ class DocumentController extends Controller
             ->get();
 
         return response()->json([
-            'discipline' => $discipline,
-            'count' => $documents->count(),
             'data' => DocumentResource::collection($documents),
+            'meta' => [
+                'discipline' => $discipline,
+                'count' => $documents->count(),
+            ],
+            'links' => [],
             'error' => null,
         ]);
     }
@@ -49,10 +52,7 @@ class DocumentController extends Controller
         $disciplineId = DisciplineMapper::idFromSlug($discipline);
 
         if ($disciplineId === null) {
-            return response()->json([
-                'message' => 'Discipline not found',
-                'error' => 'discipline_not_found',
-            ], 404);
+            return $this->disciplineNotFoundResponse();
         }
 
         $document = Document::query()
@@ -62,15 +62,40 @@ class DocumentController extends Controller
 
         if (!$document) {
             return response()->json([
-                'message' => 'Document not found',
-                'error' => 'document_not_found',
+                'data' => null,
+                'meta' => [
+                    'discipline' => $discipline,
+                    'document_id' => $id,
+                ],
+                'links' => [],
+                'error' => [
+                    'code' => 'document_not_found',
+                    'message' => 'Document not found',
+                ],
             ], 404);
         }
 
         return response()->json([
-            'discipline' => $discipline,
             'data' => new DocumentResource($document),
+            'meta' => [
+                'discipline' => $discipline,
+                'document_id' => $id,
+            ],
+            'links' => [],
             'error' => null,
         ]);
+    }
+
+    private function disciplineNotFoundResponse(): JsonResponse
+    {
+        return response()->json([
+            'data' => null,
+            'meta' => [],
+            'links' => [],
+            'error' => [
+                'code' => 'discipline_not_found',
+                'message' => 'Discipline not found',
+            ],
+        ], 404);
     }
 }

--- a/app/Http/Controllers/Api/LicenciesController.php
+++ b/app/Http/Controllers/Api/LicenciesController.php
@@ -5,24 +5,31 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use App\Models\LicenseImportSnapshot;
 use App\Models\Licencies;
-use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
 
 class LicenciesController extends Controller
 {
     /**
-     * Display a listing of the resource.
+     * Display a listing of licencies.
      */
-    public function index()
+    public function index(): JsonResponse
     {
-        $licencies = Licencies::all();
-        $count = $licencies->count();
-        return response()->json(['count' => $count, 'data' => $licencies]);
+        $licencies = Licencies::query()->get();
+
+        return response()->json([
+            'data' => $licencies,
+            'meta' => [
+                'count' => $licencies->count(),
+            ],
+            'links' => [],
+            'error' => null,
+        ]);
     }
 
-
-    public function searchByName($name)
+    public function searchByName(string $name): JsonResponse
     {
-        $licencies = Licencies::where(function ($query) use ($name) {
+        $licencies = Licencies::query()
+            ->where(function ($query) use ($name) {
                 $query->where('nom', 'like', '%' . $name . '%')
                     ->orWhere('prenom', 'like', '%' . $name . '%')
                     ->orWhere('licence', 'like', '%' . $name . '%');
@@ -31,14 +38,21 @@ class LicenciesController extends Controller
             ->distinct()
             ->get();
 
-        $count = $licencies->count();
-        return response()->json(['count' => $count, 'data' => $licencies]);
+        return response()->json([
+            'data' => $licencies,
+            'meta' => [
+                'search' => $name,
+                'count' => $licencies->count(),
+            ],
+            'links' => [],
+            'error' => null,
+        ]);
     }
 
     /**
      * Display batches of license imports.
      */
-    public function batches()
+    public function batches(): JsonResponse
     {
         $batches = LicenseImportSnapshot::query()
             ->select('import_batch_id')
@@ -46,37 +60,14 @@ class LicenciesController extends Controller
             ->distinct()
             ->get()
             ->pluck('import_batch_id');
-        return response()->json(['count' => $batches->count(), 'data' => $batches]);
-    }
-    /**
-     * Store a newly created resource in storage.
-     */
-    public function store(Request $request)
-    {
-        //
-    }
 
-    /**
-     * Display the specified resource.
-     */
-    public function show(string $id)
-    {
-        //
-    }
-
-    /**
-     * Update the specified resource in storage.
-     */
-    public function update(Request $request, string $id)
-    {
-        //
-    }
-
-    /**
-     * Remove the specified resource from storage.
-     */
-    public function destroy(string $id)
-    {
-        //
+        return response()->json([
+            'data' => $batches,
+            'meta' => [
+                'count' => $batches->count(),
+            ],
+            'links' => [],
+            'error' => null,
+        ]);
     }
 }

--- a/app/Http/Controllers/Api/LicenseImportBatchController.php
+++ b/app/Http/Controllers/Api/LicenseImportBatchController.php
@@ -10,42 +10,37 @@ use Illuminate\Http\Request;
 
 class LicenseImportBatchController extends Controller
 {
-    //
-
     public function __construct(
         private readonly TelematBatchReportBuilder $reportBuilder,
-    )
-    {
-        // Apply authentication middleware if needed
+    ) {
         // $this->middleware('auth:api');
-        
     }
 
     public function index(Request $request): JsonResponse
     {
         $query = LicenseImportBatch::query()->latestFirst();
 
-        if($request->filled('source')) {
+        if ($request->filled('source')) {
             $query->where('source', $request->string('source')->toString());
         }
 
-        if($request->filled('status')) {
+        if ($request->filled('status')) {
             $query->where('status', $request->string('status')->toString());
         }
 
-        if ($request->filled('is_active')){
+        if ($request->filled('is_active')) {
             $query->where('is_active', filter_var($request->input('is_active'), FILTER_VALIDATE_BOOL));
         }
 
-        if ($request->filled('trigger_type')){
+        if ($request->filled('trigger_type')) {
             $query->where('trigger_type', $request->string('trigger_type')->toString());
         }
 
-        if ($request->filled('from')){
+        if ($request->filled('from')) {
             $query->whereDate('started_at', '>=', $request->date('from'));
         }
 
-        if ($request->filled('to')){
+        if ($request->filled('to')) {
             $query->whereDate('started_at', '<=', $request->date('to'));
         }
 
@@ -81,11 +76,29 @@ class LicenseImportBatchController extends Controller
         return response()->json([
             'data' => $data,
             'meta' => [
+                'count' => $batches->total(),
                 'current_page' => $batches->currentPage(),
                 'last_page' => $batches->lastPage(),
                 'per_page' => $batches->perPage(),
+                'from' => $batches->firstItem(),
+                'to' => $batches->lastItem(),
                 'total' => $batches->total(),
+                'filters' => [
+                    'source' => $request->input('source'),
+                    'status' => $request->input('status'),
+                    'is_active' => $request->input('is_active'),
+                    'trigger_type' => $request->input('trigger_type'),
+                    'from' => $request->input('from'),
+                    'to' => $request->input('to'),
+                ],
             ],
+            'links' => [
+                'first' => $batches->url(1),
+                'last' => $batches->url($batches->lastPage()),
+                'prev' => $batches->previousPageUrl(),
+                'next' => $batches->nextPageUrl(),
+            ],
+            'error' => null,
         ]);
     }
 
@@ -93,6 +106,11 @@ class LicenseImportBatchController extends Controller
     {
         return response()->json([
             'data' => $this->reportBuilder->build($batch),
+            'meta' => [
+                'batch_id' => $batch->id,
+            ],
+            'links' => [],
+            'error' => null,
         ]);
     }
 
@@ -100,6 +118,11 @@ class LicenseImportBatchController extends Controller
     {
         return response()->json([
             'data' => $this->reportBuilder->build($batch),
+            'meta' => [
+                'batch_id' => $batch->id,
+            ],
+            'links' => [],
+            'error' => null,
         ]);
     }
 
@@ -124,6 +147,11 @@ class LicenseImportBatchController extends Controller
                 ],
                 'diff' => $report['projection']['diff'],
             ],
+            'meta' => [
+                'batch_id' => $batch->id,
+            ],
+            'links' => [],
+            'error' => null,
         ]);
     }
 }

--- a/app/Http/Controllers/Api/PartnerController.php
+++ b/app/Http/Controllers/Api/PartnerController.php
@@ -9,14 +9,16 @@ use Illuminate\Http\JsonResponse;
 
 class PartnerController extends Controller
 {
-    //
     public function index(): JsonResponse
     {
         $partners = Partenaire::all();
 
         return response()->json([
-            'count' => $partners->count(),
             'data' => PartnerResource::collection($partners),
+            'meta' => [
+                'count' => $partners->count(),
+            ],
+            'links' => [],
             'error' => null,
         ]);
     }

--- a/app/Http/Controllers/Api/PostController.php
+++ b/app/Http/Controllers/Api/PostController.php
@@ -6,8 +6,8 @@ use App\Http\Controllers\Controller;
 use App\Http\Resources\PostResource;
 use App\Models\Post;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Request;
 use Illuminate\Pagination\LengthAwarePaginator;
+use App\Support\DisciplineMapper;
 
 class PostController extends Controller
 {
@@ -29,7 +29,7 @@ class PostController extends Controller
 
     public function getPostsByDiscipline(string $discipline): JsonResponse
     {
-        $disciplineId = $this->getDisciplineId($discipline);
+        $disciplineId = DisciplineMapper::idFromSlug($discipline);
 
         if ($disciplineId === null) {
             return response()->json([
@@ -115,17 +115,6 @@ class PostController extends Controller
         ]));
     }
 
-    private function getDisciplineId(string $discipline): ?int
-    {
-        $mapping = [
-            'blackball' => 1,
-            'carambole' => 2,
-            'snooker' => 3,
-            'americain' => 4,
-        ];
-
-        return $mapping[$discipline] ?? null;
-    }
 
     private function paginatedResponse(LengthAwarePaginator $posts, array $extra = []): JsonResponse
     {

--- a/app/Http/Controllers/Api/PostController.php
+++ b/app/Http/Controllers/Api/PostController.php
@@ -5,9 +5,9 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\PostResource;
 use App\Models\Post;
+use App\Support\DisciplineMapper;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Pagination\LengthAwarePaginator;
-use App\Support\DisciplineMapper;
 
 class PostController extends Controller
 {
@@ -33,8 +33,13 @@ class PostController extends Controller
 
         if ($disciplineId === null) {
             return response()->json([
-                'message' => 'Discipline not found',
-                'error' => 'discipline_not_found',
+                'data' => null,
+                'meta' => [],
+                'links' => [],
+                'error' => [
+                    'code' => 'discipline_not_found',
+                    'message' => 'Discipline not found',
+                ],
             ], 404);
         }
 
@@ -64,7 +69,9 @@ class PostController extends Controller
             ->orderByDesc('created_at')
             ->paginate($this->getPerPage());
 
-        return $this->paginatedResponse($posts);
+        return $this->paginatedResponse($posts, [
+            'favoris' => true,
+        ]);
     }
 
     public function getPostByDecade(int $year): JsonResponse
@@ -80,6 +87,8 @@ class PostController extends Controller
 
         return $this->paginatedResponse($posts, [
             'decade' => "{$startDecade}-{$endDecade}",
+            'start_year' => $startDecade,
+            'end_year' => $endDecade,
         ]);
     }
 
@@ -107,28 +116,29 @@ class PostController extends Controller
         return min($perPage, 100);
     }
 
-    private function singleResponse(Post $post, array $extra = []): JsonResponse
+    private function singleResponse(Post $post, array $meta = []): JsonResponse
     {
-        return response()->json(array_merge($extra, [
+        return response()->json([
             'data' => new PostResource($post),
+            'meta' => $meta,
+            'links' => [],
             'error' => null,
-        ]));
+        ]);
     }
 
-
-    private function paginatedResponse(LengthAwarePaginator $posts, array $extra = []): JsonResponse
+    private function paginatedResponse(LengthAwarePaginator $posts, array $meta = []): JsonResponse
     {
-        return response()->json(array_merge($extra, [
-            'count' => $posts->total(),
+        return response()->json([
             'data' => PostResource::collection($posts->items()),
-            'meta' => [
+            'meta' => array_merge($meta, [
+                'count' => $posts->total(),
                 'current_page' => $posts->currentPage(),
                 'last_page' => $posts->lastPage(),
                 'per_page' => $posts->perPage(),
                 'from' => $posts->firstItem(),
                 'to' => $posts->lastItem(),
                 'total' => $posts->total(),
-            ],
+            ]),
             'links' => [
                 'first' => $posts->url(1),
                 'last' => $posts->url($posts->lastPage()),
@@ -136,6 +146,6 @@ class PostController extends Controller
                 'next' => $posts->nextPageUrl(),
             ],
             'error' => null,
-        ]));
+        ]);
     }
 }

--- a/app/Http/Controllers/Api/PublicController.php
+++ b/app/Http/Controllers/Api/PublicController.php
@@ -29,6 +29,10 @@ class PublicController extends Controller
                 'site_settings' => $siteSettings ? new SiteSettingsResource($siteSettings) : null,
                 'menus' => MenuResource::collection($menus),
             ],
+            'meta' => [
+                'menus_count' => $menus->count(),
+            ],
+            'links' => [],
             'error' => null,
         ]);
     }
@@ -46,25 +50,30 @@ class PublicController extends Controller
             ->orderBy('id')
             ->get();
 
-        $featuredPosts = Post::query()
+        $featuredPost = Post::query()
             ->where('favoris', true)
             ->orderByDesc('created_at')
             ->first();
 
-        if (!$featuredPosts) {
-            $featuredPosts = Post::query()
+        if (!$featuredPost) {
+            $featuredPost = Post::query()
                 ->orderByDesc('created_at')
                 ->first();
         }
-
 
         return response()->json([
             'data' => [
                 'site_settings' => $siteSettings ? new SiteSettingsResource($siteSettings) : null,
                 'menus' => MenuResource::collection($menus),
                 'partners' => PartnerResource::collection($partners),
-                'featured_posts' => $featuredPosts ? new PostResource($featuredPosts) : null,
+                'featured_post' => $featuredPost ? new PostResource($featuredPost) : null,
             ],
+            'meta' => [
+                'menus_count' => $menus->count(),
+                'partners_count' => $partners->count(),
+                'has_featured_post' => $featuredPost !== null,
+            ],
+            'links' => [],
             'error' => null,
         ]);
     }

--- a/app/Http/Resources/DocumentResource.php
+++ b/app/Http/Resources/DocumentResource.php
@@ -4,6 +4,7 @@ namespace App\Http\Resources;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use App\Support\DisciplineMapper;
 
 class DocumentResource extends JsonResource
 {
@@ -16,7 +17,7 @@ class DocumentResource extends JsonResource
     {
         return [
             'id' => $this->id,
-            'discipline' => $this->getDisciplineSlug(),
+            'discipline' => DisciplineMapper::slugFromId($this->discipline),
             'discipline_id' => $this->discipline,
             'title' => $this->title,
             'file' => $this->file,
@@ -26,14 +27,4 @@ class DocumentResource extends JsonResource
         ];
     }
 
-    private function getDisciplineSlug(): ?string
-    {
-        return match ((int) $this->discipline) {
-            1 => 'blackball',
-            2 => 'carambole',
-            3 => 'snooker',
-            4 => 'americain',
-            default => null,
-        };
-    }
 }

--- a/app/Http/Resources/PostResource.php
+++ b/app/Http/Resources/PostResource.php
@@ -4,6 +4,7 @@ namespace App\Http\Resources;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use App\Support\DisciplineMapper;
 
 class PostResource extends JsonResource
 {
@@ -20,7 +21,7 @@ class PostResource extends JsonResource
             'slug' => $this->slug,
             'excerpt' => $this->excerpt,
             'content' => $this->content,
-            'discipline' => $this->getDisciplineSlug(),
+            'discipline' => DisciplineMapper::slugFromId($this->discipline),
             'discipline_id' => $this->discipline,
             'year' => $this->year,
             'favoris' => (bool) $this->favoris,
@@ -30,16 +31,5 @@ class PostResource extends JsonResource
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
         ];
-    }
-
-    private function getDisciplineSlug(): ?string
-    {
-        return match ((int) $this->discipline) {
-            1 => 'blackball',
-            2 => 'carambole',
-            3 => 'snooker',
-            4 => 'americain',
-            default => null,
-        };
     }
 }

--- a/app/Services/CueScoreClubRankingService.php
+++ b/app/Services/CueScoreClubRankingService.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\ClubMatchingRule;
+use App\Models\CueScorePlayerMapping;
+use App\Models\CueScoreRanking;
+use Illuminate\Support\Collection;
+
+class CueScoreClubRankingService
+{
+    public function getActiveFetch(CueScoreRanking $ranking)
+    {
+        return $ranking->fetches()
+            ->where('is_active', true)
+            ->latest('id')
+            ->first();
+    }
+
+    public function buildIndividualRankingData(CueScoreRanking $ranking, int $fetchId, ?int $limit = null): array
+    {
+        $entries = $ranking->entries()
+            ->where('cuescore_ranking_fetch_id', $fetchId)
+            ->where('entry_type', 'player')
+            ->orderBy('rank_position')
+            ->get();
+
+        $participantIds = $entries
+            ->pluck('participant_external_id')
+            ->filter()
+            ->map(fn ($id) => (string) $id)
+            ->unique()
+            ->values();
+
+        $mappings = CueScorePlayerMapping::query()
+            ->with('licencie')
+            ->whereIn('cuescore_participant_id', $participantIds)
+            ->where('is_confirmed', true)
+            ->get()
+            ->keyBy(fn ($mapping) => (string) $mapping->cuescore_participant_id);
+
+        $data = $entries
+            ->filter(fn ($entry) => $entry->participant_external_id !== null
+                && $mappings->has((string) $entry->participant_external_id));
+
+        if ($limit !== null) {
+            $data = $data->take($limit);
+        }
+
+        $data = $data
+            ->map(function ($entry) use ($mappings) {
+                $mapping = $mappings->get((string) $entry->participant_external_id);
+                $licencie = $mapping?->licencie;
+
+                return [
+                    'rank_position' => $entry->rank_position,
+                    'participant_name' => $entry->participant_name,
+                    'participant_external_id' => $entry->participant_external_id,
+                    'participant_url' => $entry->participant_url,
+                    'points' => $entry->points,
+                    'played' => $entry->played,
+                    'wins' => $entry->wins,
+                    'losses' => $entry->losses,
+                    'ties' => $entry->ties,
+                    'matching' => [
+                        'method' => $mapping?->matching_method,
+                        'confidence_score' => $mapping?->confidence_score,
+                        'is_confirmed' => (bool) $mapping?->is_confirmed,
+                    ],
+                    'licencie' => $licencie ? [
+                        'id' => $licencie->id,
+                        'licence' => $licencie->licence ?? null,
+                        'nom' => $licencie->nom ?? null,
+                        'prenom' => $licencie->prenom ?? null,
+                    ] : null,
+                ];
+            })
+            ->values();
+
+        return [
+            'data' => $data,
+            'meta' => [],
+        ];
+    }
+
+    public function buildTeamRankingData(CueScoreRanking $ranking, int $fetchId): array
+    {
+        $entries = $ranking->entries()
+            ->where('cuescore_ranking_fetch_id', $fetchId)
+            ->where('entry_type', 'team')
+            ->orderBy('rank_position')
+            ->get();
+
+        $rules = ClubMatchingRule::query()
+            ->where('is_active', true)
+            ->get();
+
+        $hasClubTeam = $entries->contains(
+            fn ($entry) => $this->teamMatchesClubRules($entry->team_name, $rules)
+        );
+
+        if (! $hasClubTeam) {
+            return [
+                'data' => collect(),
+                'meta' => [
+                    'club_team_present' => false,
+                ],
+            ];
+        }
+
+        $data = $entries->map(function ($entry) use ($rules) {
+            return [
+                'rank_position' => $entry->rank_position,
+                'team_name' => $entry->team_name,
+                'team_external_id' => $entry->team_external_id,
+                'team_url' => $entry->team_url,
+                'points' => $entry->points,
+                'played' => $entry->played,
+                'wins' => $entry->wins,
+                'losses' => $entry->losses,
+                'ties' => $entry->ties,
+                'is_club_team' => $this->teamMatchesClubRules($entry->team_name, $rules),
+                'additional_data' => $entry->additional_data,
+            ];
+        })->values();
+
+        return [
+            'data' => $data,
+            'meta' => [
+                'club_team_present' => true,
+            ],
+        ];
+    }
+
+    public function teamMatchesClubRules(?string $teamName, Collection $rules): bool
+    {
+        $teamName = $this->normalizeClubText($teamName);
+
+        foreach ($rules as $rule) {
+            $value = $this->normalizeClubText((string) $rule->matching_value);
+
+            if ($value === '') {
+                continue;
+            }
+
+            if ($rule->matching_mode === 'contains' && str_contains($teamName, $value)) {
+                return true;
+            }
+
+            if ($rule->matching_mode === 'equals' && $teamName === $value) {
+                return true;
+            }
+
+            if ($rule->matching_mode === 'starts_with' && str_starts_with($teamName, $value)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function normalizeClubText(?string $value): string
+    {
+        if ($value === null) {
+            return '';
+        }
+
+        $value = trim($value);
+        $value = mb_strtolower($value, 'UTF-8');
+
+        $replacements = [
+            'à' => 'a', 'á' => 'a', 'â' => 'a', 'ä' => 'a',
+            'ç' => 'c',
+            'è' => 'e', 'é' => 'e', 'ê' => 'e', 'ë' => 'e',
+            'ì' => 'i', 'í' => 'i', 'î' => 'i', 'ï' => 'i',
+            'ñ' => 'n',
+            'ò' => 'o', 'ó' => 'o', 'ô' => 'o', 'ö' => 'o',
+            'ù' => 'u', 'ú' => 'u', 'û' => 'u', 'ü' => 'u',
+            'ý' => 'y', 'ÿ' => 'y',
+            '\'' => ' ',
+            '-' => ' ',
+        ];
+
+        $value = strtr($value, $replacements);
+        $value = preg_replace('/\s+/', ' ', $value) ?? $value;
+
+        return trim($value);
+    }
+}

--- a/app/Support/DisciplineMapper.php
+++ b/app/Support/DisciplineMapper.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Support;
+
+class DisciplineMapper
+{
+    public const DISCIPLINES = [
+        'blackball' => 1,
+        'carambole' => 2,
+        'snooker' => 3,
+        'americain' => 4,
+    ];
+
+    public static function idFromSlug(string $slug): ?int
+    {
+        return self::DISCIPLINES[$slug] ?? null;
+    }
+
+    public static function slugFromId(int|string|null $id): ?string
+    {
+        if ($id === null) {
+            return null;
+        }
+
+        $id = (int) $id;
+
+        return array_flip(self::DISCIPLINES)[$id] ?? null;
+    }
+
+    public static function isValidSlug(string $slug): bool
+    {
+        return array_key_exists($slug, self::DISCIPLINES);
+    }
+
+    public static function slugs(): array
+    {
+        return array_keys(self::DISCIPLINES);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -33,7 +33,7 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 // Route::post('carambole/sync', CaramboleSyncController::class)->middleware('auth:sanctum');
 
 // routes/api.php (temporaire pour debug)
-Route::post('/carambole/sync-test', \App\Http\Controllers\Api\CaramboleSyncController::class);
+// Route::post('/carambole/sync-test', \App\Http\Controllers\Api\CaramboleSyncController::class);
 
 Route::prefix('v1')->group(function () {
 
@@ -47,12 +47,12 @@ Route::prefix('v1')->group(function () {
 
     Route::prefix('/posts')->group(function () {
         Route::get('/', [PostController::class, 'index']);
-        Route::get('/{id}', [PostController::class, 'show']);
+        Route::get('/favoris', [PostController::class, 'getPostIsFavoris']);
         Route::get('/discipline/{discipline}', [PostController::class, 'getPostsByDiscipline']);
         Route::get('/slug/{slug}', [PostController::class, 'getPostBySlug']);
-        Route::get('/favoris', [PostController::class, 'getPostIsFavoris']);
         Route::get('/decade/{year}', [PostController::class, 'getPostByDecade']);
         Route::get('/year/{year}', [PostController::class, 'getPostByYear']);
+        Route::get('/{id}', [PostController::class, 'show'])->whereNumber('id');
     });
     
     
@@ -60,11 +60,13 @@ Route::prefix('v1')->group(function () {
     Route::get('/licencies/search/{name}', [LicenciesController::class, 'searchByName']);
 
     // Routes batches
-    Route::get('/license-import/batches', [LicenseImportBatchController::class, 'index']);
-    Route::get('/license-import/batches/{batch}', [LicenseImportBatchController::class, 'show']);
-    Route::get('/license-import/batches/{batch}/report', [LicenseImportBatchController::class, 'report']);
-    Route::get('/license-import/batches/{batch}/diff', [LicenseImportBatchController::class, 'diff']);
-
+    Route::middleware('auth:sanctum')->group(function () {
+        Route::get('/license-import/batches', [LicenseImportBatchController::class, 'index']);
+        Route::get('/license-import/batches/{batch}', [LicenseImportBatchController::class, 'show']);
+        Route::get('/license-import/batches/{batch}/report', [LicenseImportBatchController::class, 'report']);
+        Route::get('/license-import/batches/{batch}/diff', [LicenseImportBatchController::class, 'diff']);
+    });
+    
     // routes pour les classements CueScore
     Route::prefix('/cuescore')->group(function () {
         Route::get('/rankings', [CueScoreController::class, 'index']);
@@ -98,7 +100,7 @@ Route::prefix('v1')->group(function () {
 
     Route::prefix('/disciplines')->group(function () {
         Route::get('/{discipline}', [DisciplineController::class, 'show']);
-        Route::get('/{discipline}/ranking-preview', [DisciplineController::class, 'rankingsPreview']);
+        Route::get('/{discipline}/rankings-preview', [DisciplineController::class, 'rankingsPreview']);
     });
     
 });


### PR DESCRIPTION
## Objectif 

Finaliser la consolidation de l'API Laravel afin de la rendre plus cohérente, maintenable et prête pour l'intégration React. 

### Modifications principales

#### Harmonisation des réponses JSON

Standardisation des réponses API autour du format : 

```
{
   "data" : {},
   "meta": {},
   "links": {},
   "error": null
}
```

Contrôleurs concernés : 
* `PostController`
* `CalendarController`
* `DocumentController`
* `LicenciesController`
* `LicenseImportBatchController`
* `PartnerController`
* `PublicController`
* `CueScoreController`
* `DisciplineController`
* `ContactController`

#### Factorisation des disciplines

Ajout de `DisciplineMapper` pour centraliser la correspondance : 

```
blackball -> 1
carambole -> 2
snooker -> 3
americain -> 4
 ```

Cela évite la duplication du mapping dans plusieurs contrôleurs et resources.

#### Factorisation CueScore

Ajout de `CueScoreClubRankingService` pour centraliser la logique métier liée aux classements du club : 
* récupération du fetch actif
* filtrage des joueurs du club
* détection des équipes du club
* application des règles `ClubMatchingRule`
* normalisation des noms d'équipes

Cette logique est désormais utilisée par : 
* `CueScoreController`
* `DisciplineController`

#### Endpoint discipline consolidé

L'endpoint agrégé par discipline conserve une structure stable pour React : 

```
GET /api/v1/disciplines/{disciplines}
```
Il retourne : 
* actualités
* calendrier
* documens
* classement configurés

#### Endpoint rankings preview

L'endpoint preview reste cohérent avec l'affichage frontend : 
```
GET /api/v1/discipline/{discipline}/rangkings-preview
```
Il applique les règles métier : 
* individuel : uniquement les joueurs du club
* équipe : classement retourné uniquement si une équipe du club est présente
* exception carambole : classements non gérés pour le moment

#### Sécurisation / nettoyage
* route `carambole/sync-test` commentée pour éviter une exposition prématurée
* routes `license-import` protégées par `auth:sanctum`
* ordre des routes `posts` corrigé pour éviter les conflits avec `/{id}`

### Impact
* API plus homogène
* meilleure lisibilité des réponse côté React
* moins de duplication métier
* architecture plus maintenable
* endpoints prêts pour la consommation frontend

## Notes

Les pages légales restent pour le moment en vues Blade.
Le formulaire de contact reste géré par Laravel hors API. 