### PR TITLE
Mise en cache de public/home & /disciplines

### DIFF
--- a/app/Http/Controllers/Api/DisciplineController.php
+++ b/app/Http/Controllers/Api/DisciplineController.php
@@ -14,6 +14,8 @@ use App\Services\CueScoreClubRankingService;
 use App\Support\DisciplineMapper;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Collection;
+use App\Support\CacheKeys;
+use Illuminate\Support\Facades\Cache;
 
 class DisciplineController extends Controller
 {
@@ -28,55 +30,63 @@ class DisciplineController extends Controller
             return $this->disciplineNotFoundResponse();
         }
 
-        $disciplineId = DisciplineMapper::idFromSlug($discipline);
+        $response = Cache::remember(
+            CacheKeys::discipline($discipline),
+            now()->addMinutes(10),
+            function () use ($discipline) {
+                $disciplineId = DisciplineMapper::idFromSlug($discipline);
 
-        $posts = Post::query()
-            ->where('discipline', $disciplineId)
-            ->orderByDesc('created_at')
-            ->get();
+                $posts = Post::query()
+                    ->where('discipline', $disciplineId)
+                    ->orderByDesc('created_at')
+                    ->get();
 
-        $documents = Document::query()
-            ->where('discipline', $disciplineId)
-            ->get();
+                $documents = Document::query()
+                    ->where('discipline', $disciplineId)
+                    ->get();
 
-        $calendarEvents = Calendar::query()
-            ->active()
-            ->byDiscipline($discipline)
-            ->with(['events.links'])
-            ->get()
-            ->pluck('events')
-            ->flatten()
-            ->sortBy('date_debut')
-            ->values();
+                $calendarEvents = Calendar::query()
+                    ->active()
+                    ->byDiscipline($discipline)
+                    ->with(['events.links'])
+                    ->get()
+                    ->pluck('events')
+                    ->flatten()
+                    ->sortBy('date_debut')
+                    ->values();
 
-        $rankings = null;
+                $rankings = null;
 
-        if ($discipline !== 'carambole') {
-            $rankings = CueScoreRanking::query()
-                ->where('discipline', $discipline)
-                ->where('is_active', true)
-                ->orderBy('scope')
-                ->orderBy('ranking_type')
-                ->get();
-        }
+                if ($discipline !== 'carambole') {
+                    $rankings = CueScoreRanking::query()
+                        ->where('discipline', $discipline)
+                        ->where('is_active', true)
+                        ->orderBy('scope')
+                        ->orderBy('ranking_type')
+                        ->get();
+                }
 
-        return response()->json([
-            'data' => [
-                'posts' => PostResource::collection($posts),
-                'calendar' => CalendarEventResource::collection($calendarEvents),
-                'documents' => DocumentResource::collection($documents),
-                'rankings' => $rankings,
-            ],
-            'meta' => [
-                'discipline' => $discipline,
-                'posts_count' => $posts->count(),
-                'calendar_count' => $calendarEvents->count(),
-                'documents_count' => $documents->count(),
-                'rankings_count' => $rankings === null ? null : $rankings->count(),
-            ],
-            'links' => [],
-            'error' => null,
-        ]);
+                return [
+                    'data' => [
+                        'posts' => PostResource::collection($posts),
+                        'calendar' => CalendarEventResource::collection($calendarEvents),
+                        'documents' => DocumentResource::collection($documents),
+                        'rankings' => $rankings,
+                    ],
+                    'meta' => [
+                        'discipline' => $discipline,
+                        'posts_count' => $posts->count(),
+                        'calendar_count' => $calendarEvents->count(),
+                        'documents_count' => $documents->count(),
+                        'rankings_count' => $rankings === null ? null : $rankings->count(),
+                    ],
+                    'links' => [],
+                    'error' => null,
+                ];
+            }
+        );
+
+        return response()->json($response);
     }
 
     public function rankingsPreview(string $discipline): JsonResponse
@@ -85,87 +95,98 @@ class DisciplineController extends Controller
             return $this->disciplineNotFoundResponse();
         }
 
-        if ($discipline === 'carambole') {
-            return response()->json([
-                'data' => null,
-                'meta' => [
-                    'discipline' => $discipline,
-                    'rankings_supported' => false,
-                ],
-                'links' => [],
-                'error' => null,
-            ]);
-        }
+        $limit = $this->getPreviewLimit();
 
-        $rankings = CueScoreRanking::query()
-            ->where('discipline', $discipline)
-            ->where('is_active', true)
-            ->orderBy('scope')
-            ->orderBy('ranking_type')
-            ->orderBy('sort_order')
-            ->orderBy('id')
-            ->get();
-
-        $grouped = $rankings
-            ->map(function (CueScoreRanking $ranking) {
-                $activeFetch = $this->clubRankingService->getActiveFetch($ranking);
-
-                if ($activeFetch === null) {
-                    return null;
+        $response = Cache::remember(
+            CacheKeys::rankingsPreview($discipline, $limit),
+            now()->addMinutes(5),
+            function () use ($discipline, $limit) {
+                if ($discipline === 'carambole') {
+                    return [
+                        'data' => null,
+                        'meta' => [
+                            'discipline' => $discipline,
+                            'rankings_supported' => false,
+                        ],
+                        'links' => [],
+                        'error' => null,
+                    ];
                 }
 
-                $rankingData = $ranking->ranking_type === 'team'
-                    ? $this->clubRankingService->buildTeamRankingData($ranking, $activeFetch->id)
-                    : $this->clubRankingService->buildIndividualRankingData(
-                        $ranking,
-                        $activeFetch->id,
-                        $this->getPreviewLimit()
-                    );
+                $rankings = CueScoreRanking::query()
+                    ->where('discipline', $discipline)
+                    ->where('is_active', true)
+                    ->orderBy('scope')
+                    ->orderBy('ranking_type')
+                    ->orderBy('sort_order')
+                    ->orderBy('id')
+                    ->get();
 
-                if ($rankingData['data']->isEmpty()) {
-                    return null;
-                }
+                $grouped = $rankings
+                    ->map(function (CueScoreRanking $ranking) use ($limit) {
+                        $activeFetch = $this->clubRankingService->getActiveFetch($ranking);
+
+                        if ($activeFetch === null) {
+                            return null;
+                        }
+
+                        $rankingData = $ranking->ranking_type === 'team'
+                            ? $this->clubRankingService->buildTeamRankingData($ranking, $activeFetch->id)
+                            : $this->clubRankingService->buildIndividualRankingData(
+                                $ranking,
+                                $activeFetch->id,
+                                $limit
+                            );
+
+                        if ($rankingData['data']->isEmpty()) {
+                            return null;
+                        }
+
+                        return [
+                            'scope' => $ranking->scope,
+                            'ranking' => [
+                                'id' => $ranking->id,
+                                'name' => $ranking->name,
+                                'cuescore_id' => $ranking->cuescore_id,
+                                'url' => $ranking->url,
+                                'source_type' => $ranking->source_type,
+                                'discipline' => $ranking->discipline,
+                                'scope' => $ranking->scope,
+                                'ranking_type' => $ranking->ranking_type,
+                                'team_category' => $ranking->team_category,
+                                'season' => $ranking->season,
+                                'is_active' => (bool) $ranking->is_active,
+                                'sort_order' => $ranking->sort_order,
+                            ],
+                            'entries' => $rankingData['data']->values(),
+                            'meta' => $rankingData['meta'],
+                        ];
+                    })
+                    ->filter()
+                    ->groupBy('scope')
+                    ->map(function (Collection $items) {
+                        return $items->map(function (array $item) {
+                            unset($item['scope']);
+
+                            return $item;
+                        })->values();
+                    });
 
                 return [
-                    'scope' => $ranking->scope,
-                    'ranking' => [
-                        'id' => $ranking->id,
-                        'name' => $ranking->name,
-                        'cuescore_id' => $ranking->cuescore_id,
-                        'url' => $ranking->url,
-                        'source_type' => $ranking->source_type,
-                        'discipline' => $ranking->discipline,
-                        'scope' => $ranking->scope,
-                        'ranking_type' => $ranking->ranking_type,
-                        'team_category' => $ranking->team_category,
-                        'season' => $ranking->season,
-                        'is_active' => (bool) $ranking->is_active,
-                        'sort_order' => $ranking->sort_order,
+                    'data' => $grouped,
+                    'meta' => [
+                        'discipline' => $discipline,
+                        'count' => $grouped->flatten(1)->count(),
+                        'limit' => $limit,
+                        'rankings_supported' => true,
                     ],
-                    'entries' => $rankingData['data']->values(),
-                    'meta' => $rankingData['meta'],
+                    'links' => [],
+                    'error' => null,
                 ];
-            })
-            ->filter()
-            ->groupBy('scope')
-            ->map(function (Collection $items) {
-                return $items->map(function (array $item) {
-                    unset($item['scope']);
-                    return $item;
-                })->values();
-            });
+            }
+        );
 
-        return response()->json([
-            'data' => $grouped,
-            'meta' => [
-                'discipline' => $discipline,
-                'count' => $grouped->flatten(1)->count(),
-                'limit' => $this->getPreviewLimit(),
-                'rankings_supported' => true,
-            ],
-            'links' => [],
-            'error' => null,
-        ]);
+        return response()->json($response);
     }
 
     private function getPreviewLimit(): int

--- a/app/Http/Controllers/Api/PublicController.php
+++ b/app/Http/Controllers/Api/PublicController.php
@@ -11,7 +11,9 @@ use App\Models\Menu;
 use App\Models\Partenaire;
 use App\Models\Post;
 use App\Models\SiteSetting;
+use App\Support\CacheKeys;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Cache;
 
 class PublicController extends Controller
 {
@@ -39,42 +41,50 @@ class PublicController extends Controller
 
     public function home(): JsonResponse
     {
-        $siteSettings = SiteSetting::query()->first();
+        $response = Cache::remember(
+            CacheKeys::publicHome(),
+            now()->addMinutes(10),
+            function () {
+                $siteSettings = SiteSetting::query()->first();
 
-        $menus = Menu::query()
-            ->where('actif', true)
-            ->orderBy('id')
-            ->get();
+                $menus = Menu::query()
+                    ->where('actif', true)
+                    ->orderBy('id')
+                    ->get();
 
-        $partners = Partenaire::query()
-            ->orderBy('id')
-            ->get();
+                $partners = Partenaire::query()
+                    ->orderBy('id')
+                    ->get();
 
-        $featuredPost = Post::query()
-            ->where('favoris', true)
-            ->orderByDesc('created_at')
-            ->first();
+                $featuredPost = Post::query()
+                    ->where('favoris', true)
+                    ->orderByDesc('created_at')
+                    ->first();
 
-        if (!$featuredPost) {
-            $featuredPost = Post::query()
-                ->orderByDesc('created_at')
-                ->first();
-        }
+                if (!$featuredPost) {
+                    $featuredPost = Post::query()
+                        ->orderByDesc('created_at')
+                        ->first();
+                }
 
-        return response()->json([
-            'data' => [
-                'site_settings' => $siteSettings ? new SiteSettingsResource($siteSettings) : null,
-                'menus' => MenuResource::collection($menus),
-                'partners' => PartnerResource::collection($partners),
-                'featured_post' => $featuredPost ? new PostResource($featuredPost) : null,
-            ],
-            'meta' => [
-                'menus_count' => $menus->count(),
-                'partners_count' => $partners->count(),
-                'has_featured_post' => $featuredPost !== null,
-            ],
-            'links' => [],
-            'error' => null,
-        ]);
+                return [
+                    'data' => [
+                        'site_settings' => $siteSettings ? new SiteSettingsResource($siteSettings) : null,
+                        'menus' => MenuResource::collection($menus),
+                        'partners' => PartnerResource::collection($partners),
+                        'featured_post' => $featuredPost ? new PostResource($featuredPost) : null,
+                    ],
+                    'meta' => [
+                        'menus_count' => $menus->count(),
+                        'partners_count' => $partners->count(),
+                        'has_featured_post' => $featuredPost !== null,
+                    ],
+                    'links' => [],
+                    'error' => null,
+                ];
+            }
+        );
+
+        return response()->json($response);
     }
 }

--- a/app/Support/CacheKeys.php
+++ b/app/Support/CacheKeys.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Support;
+
+class CacheKeys
+{
+    public static function publicHome(): string
+    {
+        return 'public_home';
+    }
+
+    public static function discipline(string $slug): string
+    {
+        return "discipline:{$slug}";
+    }
+
+    public static function rankingsPreview(string $slug, int $limit): string
+    {
+        return "discipline:{$slug}:rankings_preview:limit:{$limit}";
+    }
+}


### PR DESCRIPTION
## Résumé

Ajoute une mise en cache courte sur les endpoints publics principaux afin de réduire les recalculs et les requêtes base de données.

## Changements

- Ajout de `App\Support\CacheKeys`
- Cache de `/public/home` pendant 10 minutes
- Cache de `/disciplines/{discipline}` pendant 10 minutes
- Cache de `/disciplines/{discipline}/rankings-preview` pendant 5 minutes
- Prise en compte du paramètre `limit` dans la clé de cache rankings preview

## Tests

- `php artisan optimize:clear`
- `php artisan test`

Résultat :

```txt
155 passed
```

## Notes
* Le TTL est volontairement court pour limiter les incohérences de données
* Les clés de cache sont centralisées pour éviter les collisions et faciliter la maintenance