### PR TITLE
Ameliorations audit : seeder idempotent, imports async, tests + fixes schema

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,11 @@ BROADCAST_DRIVER=log
 CACHE_DRIVER=file
 FILESYSTEM_DISK=local
 QUEUE_CONNECTION=sync
+
+# Connexion des imports declenches depuis l'admin (licences Telemat, CueScore).
+# "database" = traitement en arriere-plan : NECESSITE un worker `php artisan queue:work`.
+# Mettre "sync" pour une execution inline (bloquante) sans worker.
+ADMIN_IMPORT_QUEUE_CONNECTION=database
 SESSION_DRIVER=file
 SESSION_LIFETIME=120
 

--- a/app/Admin/Controllers/CueScorePlayerMappingController.php
+++ b/app/Admin/Controllers/CueScorePlayerMappingController.php
@@ -2,10 +2,10 @@
 
 namespace App\Admin\Controllers;
 
+use App\Jobs\RunCueScoreImportJob;
 use App\Models\CueScorePlayerMapping;
 use App\Models\Licencies;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Artisan;
 use OpenAdmin\Admin\Controllers\AdminController;
 use OpenAdmin\Admin\Form;
 use OpenAdmin\Admin\Grid;
@@ -165,25 +165,22 @@ class CueScorePlayerMappingController extends AdminController
     public function run(Request $request)
     {
         $discipline = $request->query('discipline');
+        $discipline = ($discipline && in_array($discipline, self::DISCIPLINES, true)) ? $discipline : null;
 
-        $params = [
-            '--with-match'  => true,
-            '--active-only' => true,
-        ];
-
-        if ($discipline && in_array($discipline, self::DISCIPLINES, true)) {
-            $params['--discipline'] = $discipline;
-        }
+        $connection = config('queue.admin_import_connection', 'database');
+        $suffix = $discipline ? ' (' . $discipline . ')' : '';
 
         try {
-            Artisan::call('cuescore:import', $params);
-            $output = trim(Artisan::output());
-            $tail = collect(preg_split('/\r?\n/', $output))->filter()->take(-6)->implode(' | ');
+            RunCueScoreImportJob::dispatch($discipline)->onConnection($connection);
 
-            admin_success(
-                'Import CueScore termine' . ($discipline ? ' (' . $discipline . ')' : ''),
-                $tail !== '' ? $tail : 'Aucune sortie.'
-            );
+            if ($connection === 'sync') {
+                admin_success('Import CueScore termine' . $suffix, 'Import et matching executes.');
+            } else {
+                admin_success(
+                    'Import CueScore lance' . $suffix,
+                    'Traitement en arriere-plan (un worker « php artisan queue:work » doit tourner).'
+                );
+            }
         } catch (\Throwable $e) {
             admin_error('Echec de l\'import CueScore', $e->getMessage());
         }

--- a/app/Admin/Controllers/LicenseImportBatchAdminController.php
+++ b/app/Admin/Controllers/LicenseImportBatchAdminController.php
@@ -188,26 +188,38 @@ class LicenseImportBatchAdminController extends AdminController
             dryRun: $dryRun,
         );
 
+        $connection = config('queue.admin_import_connection', 'database');
+
         try {
             RunTelematLicenseImportJob::dispatch($context->toArray())
+                ->onConnection($connection)
                 ->onQueue(config('license_import.job.queue', 'default'));
 
-            $batch = LicenseImportBatch::latestFirst()->first();
-            $statusValue = $batch?->status instanceof BatchStatus
-                ? $batch->status->value
-                : (string) ($batch?->status ?? 'inconnu');
+            if ($connection === 'sync') {
+                // Execution inline : le batch est disponible immediatement.
+                $batch = LicenseImportBatch::latestFirst()->first();
+                $statusValue = $batch?->status instanceof BatchStatus
+                    ? $batch->status->value
+                    : (string) ($batch?->status ?? 'inconnu');
 
-            admin_success(
-                $dryRun ? 'Dry-run termine' : 'Import termine',
-                sprintf(
-                    'Batch #%s - statut : %s - %d ligne(s), %d valide(s), %d invalide(s).',
-                    $batch?->id ?? '?',
-                    $statusValue,
-                    $batch?->raw_rows_count ?? 0,
-                    $batch?->valid_rows_count ?? 0,
-                    $batch?->invalid_rows_count ?? 0,
-                )
-            );
+                admin_success(
+                    $dryRun ? 'Dry-run termine' : 'Import termine',
+                    sprintf(
+                        'Batch #%s - statut : %s - %d ligne(s), %d valide(s), %d invalide(s).',
+                        $batch?->id ?? '?',
+                        $statusValue,
+                        $batch?->raw_rows_count ?? 0,
+                        $batch?->valid_rows_count ?? 0,
+                        $batch?->invalid_rows_count ?? 0,
+                    )
+                );
+            } else {
+                admin_success(
+                    $dryRun ? 'Dry-run lance' : 'Import lance',
+                    'Traitement en arriere-plan. Rafraichissez la liste des batches dans quelques instants '
+                    . '(un worker « php artisan queue:work » doit tourner).'
+                );
+            }
         } catch (\Throwable $e) {
             admin_error(
                 'Echec de l\'import',

--- a/app/Jobs/RunCueScoreImportJob.php
+++ b/app/Jobs/RunCueScoreImportJob.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Execute l'import CueScore (cuescore:import --with-match --active-only) en
+ * arriere-plan, pour ne pas bloquer la requete admin. Optionnellement cible une
+ * discipline.
+ */
+class RunCueScoreImportJob implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $timeout = 900;
+
+    public function __construct(
+        public ?string $discipline = null,
+    ) {
+    }
+
+    public function handle(): void
+    {
+        $params = [
+            '--with-match'  => true,
+            '--active-only' => true,
+        ];
+
+        if ($this->discipline) {
+            $params['--discipline'] = $this->discipline;
+        }
+
+        Artisan::call('cuescore:import', $params);
+
+        Log::info('cuescore.import.job.completed', [
+            'discipline' => $this->discipline,
+            'output' => trim(Artisan::output()),
+        ]);
+    }
+}

--- a/app/Models/Licencies.php
+++ b/app/Models/Licencies.php
@@ -13,6 +13,9 @@ final class Licencies extends Model
 
     protected $guarded = [];
 
+    // La table licencies n'a pas de colonnes created_at / updated_at.
+    public $timestamps = false;
+
     public function playerMappings(): HasMany
     {
         return $this->hasMany(CueScorePlayerMapping::class, 'licencie_id');

--- a/config/queue.php
+++ b/config/queue.php
@@ -17,6 +17,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Connexion des imports declenches depuis l'admin
+    |--------------------------------------------------------------------------
+    |
+    | Les boutons d'import (licences Telemat, CueScore) s'executent sur cette
+    | connexion. Par defaut "database" : traitement en arriere-plan, ce qui
+    | necessite un worker (php artisan queue:work). Mettre "sync" pour revenir a
+    | une execution inline (bloquante) sans worker.
+    |
+    */
+
+    'admin_import_connection' => env('ADMIN_IMPORT_QUEUE_CONNECTION', 'database'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Queue Connections
     |--------------------------------------------------------------------------
     |

--- a/database/migrations/2026_04_21_130927_create_cuescore_player_mappings_table.php
+++ b/database/migrations/2026_04_21_130927_create_cuescore_player_mappings_table.php
@@ -18,9 +18,12 @@ return new class extends Migration
             $table->string('cuescore_name');
             $table->string('cuescore_url')->nullable();
             
+            // Nullable : un participant CueScore sans correspondance fiable reste
+            // stocke avec licencie_id = null (voir CueScorePlayerMatcher).
             $table->foreignId('licencie_id')
+                ->nullable()
                 ->constrained('licencies')
-                ->onDelete('cascade');
+                ->nullOnDelete();
 
             $table->string('matching_method', 30)->index();
             $table->unsignedTinyInteger('confidence_score')->nullable();

--- a/database/migrations/2026_07_15_000007_create_jobs_table.php
+++ b/database/migrations/2026_07_15_000007_create_jobs_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Table de file d'attente `database` : permet d'executer les imports declenches
+ * depuis l'admin en arriere-plan (via un worker queue:work) au lieu de bloquer
+ * la requete HTTP. La table `failed_jobs` existe deja.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('jobs')) {
+            return;
+        }
+
+        Schema::create('jobs', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('queue')->index();
+            $table->longText('payload');
+            $table->unsignedTinyInteger('attempts');
+            $table->unsignedInteger('reserved_at')->nullable();
+            $table->unsignedInteger('available_at');
+            $table->unsignedInteger('created_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('jobs');
+    }
+};

--- a/database/seeders/CueScoreRankingSeeder.php
+++ b/database/seeders/CueScoreRankingSeeder.php
@@ -565,18 +565,14 @@ class CueScoreRankingSeeder extends Seeder
 
         ];
 
-        DB::table('cuescore_rankings')->delete(); // Optionnel : vide la table avant d'insérer les nouvelles données
-        
-        $driver = DB::getDriverName();
-
-        if ($driver === 'mysql') {
-            DB::statement('ALTER TABLE cuescore_rankings AUTO_INCREMENT = 1');
+        // Upsert idempotent par cuescore_id : re-seeder ne vide plus la table.
+        // Les editions faites via le CRUD admin sont preservees, et la colonne
+        // `category` (absente ici) n'est jamais ecrasee.
+        foreach ($rankings as $ranking) {
+            DB::table('cuescore_rankings')->updateOrInsert(
+                ['cuescore_id' => $ranking['cuescore_id']],
+                $ranking + ['updated_at' => now()]
+            );
         }
-
-        if ($driver === 'sqlite') {
-            DB::statement("DELETE FROM sqlite_sequence WHERE name = 'cuescore_rankings'");
-        }
-
-        DB::table('cuescore_rankings')->insert($rankings);
     }
 }

--- a/tests/Feature/CueScore/CueScorePlayerMatcherTest.php
+++ b/tests/Feature/CueScore/CueScorePlayerMatcherTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Tests\Feature\CueScore;
+
+use App\Models\CueScorePlayerMapping;
+use App\Models\CueScoreRanking;
+use App\Models\CueScoreRankingEntry;
+use App\Models\CueScoreRankingFetch;
+use App\Models\Licencies;
+use App\Services\CueScore\CueScorePlayerMatcher;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class CueScorePlayerMatcherTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function makeFetch(): CueScoreRankingFetch
+    {
+        $ranking = CueScoreRanking::create([
+            'name' => 'Test',
+            'cuescore_id' => '123',
+            'url' => 'https://cuescore.com/ranking/test/123',
+            'source_type' => 'ranking',
+            'discipline' => 'blackball',
+            'scope' => 'national',
+            'ranking_type' => 'individual',
+            'team_category' => null,
+            'season' => '2025-2026',
+            'is_active' => true,
+            'sort_order' => 1,
+        ]);
+
+        return CueScoreRankingFetch::create([
+            'cuescore_ranking_id' => $ranking->id,
+            'status' => 'success',
+            'fetched_at' => now(),
+            'is_active' => true,
+            'records_count' => 0,
+        ]);
+    }
+
+    private function addEntry(CueScoreRankingFetch $fetch, string $name, string $externalId): void
+    {
+        CueScoreRankingEntry::create([
+            'cuescore_ranking_id' => $fetch->cuescore_ranking_id,
+            'cuescore_ranking_fetch_id' => $fetch->id,
+            'entry_type' => 'player',
+            'participant_name' => $name,
+            'participant_external_id' => $externalId,
+        ]);
+    }
+
+    public function test_exact_match_is_linked_and_confirmed_and_unmatched_stays_null(): void
+    {
+        $jean = Licencies::create(['licence' => 'L1', 'nom' => 'Dupont', 'prenom' => 'Jean', 'url' => null]);
+        Licencies::create(['licence' => 'L2', 'nom' => 'Curie', 'prenom' => 'Marie', 'url' => null]);
+
+        $fetch = $this->makeFetch();
+        // Accents/casse differents mais normalisation identique -> match exact.
+        $this->addEntry($fetch, 'JEAN Dupont', 'E1');
+        $this->addEntry($fetch, 'Zzzz Qqqq', 'E2');
+
+        $count = app(CueScorePlayerMatcher::class)->matchEntriesForFetch($fetch->id);
+
+        $this->assertSame(2, $count);
+
+        $m1 = CueScorePlayerMapping::where('cuescore_participant_id', 'E1')->firstOrFail();
+        $this->assertSame($jean->id, $m1->licencie_id);
+        $this->assertSame(100, $m1->confidence_score);
+        $this->assertTrue((bool) $m1->is_confirmed);
+        $this->assertSame('exact_normalized', $m1->matching_method);
+
+        $m2 = CueScorePlayerMapping::where('cuescore_participant_id', 'E2')->firstOrFail();
+        $this->assertNull($m2->licencie_id);
+        $this->assertFalse((bool) $m2->is_confirmed);
+    }
+
+    public function test_licencies_are_loaded_once_per_fetch(): void
+    {
+        foreach (range(1, 5) as $i) {
+            Licencies::create(['licence' => "L$i", 'nom' => "Nom$i", 'prenom' => "Prenom$i", 'url' => null]);
+        }
+
+        $fetch = $this->makeFetch();
+        foreach (range(1, 3) as $i) {
+            $this->addEntry($fetch, "Joueur $i", "E$i");
+        }
+
+        DB::enableQueryLog();
+        app(CueScorePlayerMatcher::class)->matchEntriesForFetch($fetch->id);
+
+        $licencieLoads = collect(DB::getQueryLog())
+            ->filter(fn ($q) => str_contains($q['query'], '"licencies"'))
+            ->count();
+
+        // Refactor perf : la table licencies est chargee une seule fois pour
+        // tout le fetch, quel que soit le nombre d'entrees.
+        $this->assertSame(1, $licencieLoads);
+    }
+}

--- a/tests/Feature/CueScore/CueScoreRankingSeederTest.php
+++ b/tests/Feature/CueScore/CueScoreRankingSeederTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Feature\CueScore;
+
+use App\Models\CueScoreRanking;
+use Database\Seeders\CueScoreRankingSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CueScoreRankingSeederTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_seeder_is_idempotent_and_preserves_category(): void
+    {
+        $this->seed(CueScoreRankingSeeder::class);
+
+        $countAfterFirst = CueScoreRanking::count();
+        $this->assertGreaterThan(0, $countAfterFirst);
+
+        // Simule une edition faite via le CRUD admin (categorie posee a la main).
+        $ranking = CueScoreRanking::query()->first();
+        $ranking->update(['category' => 'Categorie manuelle']);
+
+        // Re-seed : ne doit ni dupliquer, ni ecraser la categorie.
+        $this->seed(CueScoreRankingSeeder::class);
+
+        $this->assertSame($countAfterFirst, CueScoreRanking::count());
+        $this->assertSame('Categorie manuelle', $ranking->fresh()->category);
+    }
+}


### PR DESCRIPTION
## Objectif

Améliorations issues de l'audit qualité (suite de #64) : seeder sûr, imports non bloquants, et couverture de tests — qui a révélé 2 bugs de schéma corrigés au passage.

## Contenu (3 commits)

### #3 — Seeder idempotent
`CueScoreRankingSeeder` faisait `delete()` + `insert()` → chaque `db:seed` vidait la table et écrasait catégories + éditions faites via le CRUD admin. Passage à un `updateOrInsert` par `cuescore_id` ; la colonne `category` n'est jamais écrasée.

### #4 — Imports en arrière-plan (queue database)
Les boutons d'import (licences Telemat, CueScore) bloquaient la requête HTTP (`sync`) ; « Importer tout + matcher » pouvait dépasser `max_execution_time`.
- Table `jobs` + job `RunCueScoreImportJob`.
- Les deux `run()` dispatchent sur `config('queue.admin_import_connection')` (env `ADMIN_IMPORT_QUEUE_CONNECTION`, défaut `database`) et rendent la main immédiatement.

**Nécessite un worker `php artisan queue:work`** (local + prod). Mettre `ADMIN_IMPORT_QUEUE_CONNECTION=sync` pour revenir à l'exécution inline.

### #5 — Tests + 2 bugs de schéma corrigés
Tests (SQLite en mémoire) :
- **Matcher** : correspondance exacte (liée + confirmée, score 100), non-correspondance (`licencie_id` null), et non-régression du refactor perf (licenciés chargés **une seule fois** par fetch).
- **Seeder** : idempotence + préservation de la catégorie.

Bugs latents révélés par les tests :
- **Modèle `Licencies`** : `timestamps` désactivés (la table n'a pas `created_at`/`updated_at`) → tout `create()`/`save()` Eloquent échouait, **y compris l'édition d'un licencié via l'admin**.
- **Migration `cuescore_player_mappings`** : `licencie_id` rendu `nullable` + `nullOnDelete` dès la création. L'ancienne migration « alter nullable » **skippe SQLite**, donc une install fraîche créait la colonne NOT NULL et le matcher cassait au premier participant non apparié. État final identique en prod (déjà nullable).

## Déploiement

```bash
php artisan migrate   # cree la table jobs
```
- Definir `ADMIN_IMPORT_QUEUE_CONNECTION` et lancer un worker `queue:work` (ou mettre `sync`).
- La migration de creation modifiée n'affecte **que les installs fraîches** (la prod est déjà migrée).

## Vérifications
- Suite complète : **175 tests OK** (2985 assertions).
- Les boutons d'import enfilent un job sans l'exécuter inline (async confirmé).
- Seeder idempotent vérifié (37 lignes stables, catégorie préservée).
