### PR TITLE
LOT 1 — Carrousel infini accessible des partenaires

### DIFF
--- a/app/Admin/Controllers/AdminPartenairesController.php
+++ b/app/Admin/Controllers/AdminPartenairesController.php
@@ -30,6 +30,9 @@ class AdminPartenairesController extends AdminController
     {
         $grid = new Grid(new Partenaire());
 
+        $grid->model()->orderBy('ordre')->orderBy('id');
+
+        $grid->column('ordre', __('Ordre'))->sortable();
         $grid->column('titre', __('Titre'));
         $grid->column('img', __('Image'))->display(function ($thumbnail) {
             // Vérifie si le thumbnail existe et est non vide
@@ -41,6 +44,12 @@ class AdminPartenairesController extends AdminController
             return '<img src="' . asset('storage/' . $thumbnail) . '" alt="Thumbnail" class="object-cover" style="width:48px; height:auto;">';
         });
         $grid->column('url', __('URL'));
+        $grid->column('actif', __('Actif'))->display(function ($v) {
+            return $v
+                ? '<span class="badge badge-success">actif</span>'
+                : '<span class="badge badge-default">inactif</span>';
+        });
+        $grid->column('date_fin', __('Fin'));
 
         return $grid;
     }
@@ -63,7 +72,12 @@ class AdminPartenairesController extends AdminController
         
             return '<img src="' . asset('storage/' . $thumbnail) . '" alt="Thumbnail" class="object-cover" style="width:192px; height:auto;">';
         });
+        $show->field('alt', __('Texte alternatif'));
         $show->field('url', __('URL'));
+        $show->field('ordre', __('Ordre d\'affichage'));
+        $show->field('actif', __('Actif'))->as(fn ($v) => $v ? 'Oui' : 'Non');
+        $show->field('date_debut', __('Debut du partenariat'));
+        $show->field('date_fin', __('Fin du partenariat'));
 
         return $show;
     }
@@ -78,9 +92,21 @@ class AdminPartenairesController extends AdminController
         $form = new Form(new Partenaire());
 
         $form->text('titre', __('Titre'))->required();
-        $form->file('img', __('Image'))->removable();
+        $form->file('img', __('Image'))->removable()
+            ->help('Logo du partenaire. Format conseille : PNG ou JPG, fond transparent ou blanc.');
         $form->ignore(['img']);
-        $form->url('url', __('URL'));
+        $form->text('alt', __('Texte alternatif'))
+            ->help('Decrit le logo pour l\'accessibilite et les lecteurs d\'ecran (ex : « Logo Intersport »). Si vide, le nom est utilise.');
+        $form->url('url', __('Site web (URL)'))
+            ->help('Facultatif. Si renseignee, le logo devient cliquable vers le site du partenaire.');
+        $form->number('ordre', __('Ordre d\'affichage'))->default(0)
+            ->help('Plus le nombre est petit, plus le partenaire apparait tot dans le carrousel.');
+        $form->switch('actif', __('Actif'))->default(true)
+            ->help('Desactiver masque le partenaire du site public, sans le supprimer.');
+        $form->date('date_debut', __('Debut du partenariat'))
+            ->help('Facultatif. Avant cette date, le partenaire n\'est pas affiche.');
+        $form->date('date_fin', __('Fin du partenariat'))
+            ->help('Facultatif. Apres cette date, le partenaire n\'est plus affiche (mais reste enregistre).');
 
         $form->saving(function ($form) {
             /** @var \Illuminate\Http\UploadedFile|null $file */

--- a/app/Http/Controllers/Api/PartnerController.php
+++ b/app/Http/Controllers/Api/PartnerController.php
@@ -37,7 +37,7 @@ class PartnerController extends Controller
      */
     public function index(): JsonResponse
     {
-        $partners = Partenaire::all();
+        $partners = Partenaire::visible()->get();
 
         return response()->json([
             'data' => PartnerResource::collection($partners),

--- a/app/Http/Controllers/Api/PublicController.php
+++ b/app/Http/Controllers/Api/PublicController.php
@@ -187,9 +187,7 @@ class PublicController extends Controller
                     ->orderBy('id')
                     ->get();
 
-                $partners = Partenaire::query()
-                    ->orderBy('id')
-                    ->get();
+                $partners = Partenaire::visible()->get();
 
                 $featuredPost = Post::query()
                     ->where('favoris', true)

--- a/app/Http/Resources/PartnerResource.php
+++ b/app/Http/Resources/PartnerResource.php
@@ -20,6 +20,8 @@ class PartnerResource extends JsonResource
             'logo' => $this->img,
             'logo_url' => $this->img ? asset('storage/' . $this->img) : null,
             'website_url' => $this->url,
+            'alt' => $this->alt,
+            'order' => $this->ordre,
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
         ];

--- a/app/Models/Partenaire.php
+++ b/app/Models/Partenaire.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Support\ApiCacheInvalidator;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 
@@ -9,10 +10,50 @@ class Partenaire extends Model
 {
     use HasFactory;
 
+    /**
+     * Les partenaires sont affiches sur la page d'accueil (mise en cache) :
+     * toute creation / modification / suppression invalide ce cache pour que
+     * les changements faits en admin soient visibles immediatement.
+     */
+    protected static function booted(): void
+    {
+        $forget = static fn () => app(ApiCacheInvalidator::class)->publicHome();
+
+        static::saved($forget);
+        static::deleted($forget);
+    }
+
     protected $fillable = [
         'titre',
         'img',
         'url',
-        'created_at',
+        'ordre',
+        'actif',
+        'alt',
+        'date_debut',
+        'date_fin',
     ];
+
+    protected $casts = [
+        'actif' => 'boolean',
+        'ordre' => 'integer',
+        'date_debut' => 'date',
+        'date_fin' => 'date',
+    ];
+
+    /**
+     * Partenaires visibles publiquement : actifs et dans leur fenetre de
+     * partenariat (dates facultatives), tries par ordre d'affichage.
+     */
+    public function scopeVisible($query)
+    {
+        $today = now()->toDateString();
+
+        return $query
+            ->where('actif', true)
+            ->where(fn ($q) => $q->whereNull('date_debut')->orWhere('date_debut', '<=', $today))
+            ->where(fn ($q) => $q->whereNull('date_fin')->orWhere('date_fin', '>=', $today))
+            ->orderBy('ordre')
+            ->orderBy('id');
+    }
 }

--- a/database/migrations/2026_07_16_000001_add_display_fields_to_partenaires_table.php
+++ b/database/migrations/2026_07_16_000001_add_display_fields_to_partenaires_table.php
@@ -1,0 +1,49 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Champs d'affichage des partenaires (carrousel page d'accueil) :
+ * ordre, statut actif, texte alternatif et fenetre de partenariat.
+ *
+ * Un partenaire dont le partenariat est termine n'est pas supprime : il est
+ * desactive (actif = false) ou sort de la fenetre date_debut / date_fin.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('partenaires', function (Blueprint $table) {
+            if (! Schema::hasColumn('partenaires', 'ordre')) {
+                $table->unsignedInteger('ordre')->default(0)->after('url');
+            }
+            if (! Schema::hasColumn('partenaires', 'actif')) {
+                $table->boolean('actif')->default(true)->after('ordre');
+            }
+            if (! Schema::hasColumn('partenaires', 'alt')) {
+                $table->string('alt')->nullable()->after('actif');
+            }
+            if (! Schema::hasColumn('partenaires', 'date_debut')) {
+                $table->date('date_debut')->nullable()->after('alt');
+            }
+            if (! Schema::hasColumn('partenaires', 'date_fin')) {
+                $table->date('date_fin')->nullable()->after('date_debut');
+            }
+        });
+
+        // Ordre initial stable pour les partenaires existants (par id).
+        foreach (DB::table('partenaires')->orderBy('id')->pluck('id') as $index => $id) {
+            DB::table('partenaires')->where('id', $id)->update(['ordre' => $index + 1]);
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::table('partenaires', function (Blueprint $table) {
+            $table->dropColumn(['ordre', 'actif', 'alt', 'date_debut', 'date_fin']);
+        });
+    }
+};

--- a/frontend/src/components/partners/PartnersCarousel.tsx
+++ b/frontend/src/components/partners/PartnersCarousel.tsx
@@ -1,0 +1,116 @@
+import { useEffect, useState } from "react";
+import type { Partner } from "../../types/api";
+import "../../styles/partnersCarousel.css";
+
+/**
+ * En dessous de ce nombre de partenaires, le defilement automatique n'apporte
+ * rien (la piste ne remplit pas l'ecran) : on affiche une rangee statique
+ * centree. Au-dela, on active le carrousel infini.
+ */
+const MIN_FOR_SCROLL = 4;
+
+function usePrefersReducedMotion(): boolean {
+    const [reduced, setReduced] = useState(false);
+
+    useEffect(() => {
+        const query = window.matchMedia("(prefers-reduced-motion: reduce)");
+        setReduced(query.matches);
+        const onChange = () => setReduced(query.matches);
+        query.addEventListener("change", onChange);
+        return () => query.removeEventListener("change", onChange);
+    }, []);
+
+    return reduced;
+}
+
+type PartnerItemProps = {
+    partner: Partner;
+    /** Element visuel duplique pour la boucle : masque aux technologies d'assistance. */
+    duplicated?: boolean;
+};
+
+function PartnerItem({ partner, duplicated = false }: PartnerItemProps) {
+    const [imageFailed, setImageFailed] = useState(false);
+
+    const label = partner.alt || partner.name || partner.nom || "Partenaire";
+    const showImage = Boolean(partner.logo_url) && !imageFailed;
+
+    const inner = showImage ? (
+        <img
+            className="partners-carousel__logo"
+            src={partner.logo_url as string}
+            alt={duplicated ? "" : label}
+            loading="lazy"
+            onError={() => setImageFailed(true)}
+        />
+    ) : (
+        <span className="partners-carousel__fallback">{label}</span>
+    );
+
+    const hasLink = Boolean(partner.website_url);
+
+    return (
+        <li className="partners-carousel__item" aria-hidden={duplicated || undefined}>
+            {hasLink ? (
+                <a
+                    className="partners-carousel__link"
+                    href={partner.website_url as string}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    tabIndex={duplicated ? -1 : undefined}
+                    aria-label={duplicated ? undefined : `${label} (ouvre un nouvel onglet)`}
+                >
+                    {inner}
+                </a>
+            ) : (
+                inner
+            )}
+        </li>
+    );
+}
+
+type PartnersCarouselProps = {
+    partners: Partner[];
+};
+
+/**
+ * Carrousel infini et accessible des partenaires actifs.
+ *
+ * - Defilement continu par CSS (aucune dependance JS lourde).
+ * - Boucle sans saut : la liste est dupliquee, la copie etant masquee aux
+ *   technologies d'assistance (aria-hidden) et non focusable.
+ * - Respecte prefers-reduced-motion et le faible nombre de partenaires en
+ *   basculant sur une liste statique.
+ */
+export function PartnersCarousel({ partners }: PartnersCarouselProps) {
+    const prefersReducedMotion = usePrefersReducedMotion();
+
+    if (!partners.length) {
+        return null;
+    }
+
+    const animate = partners.length >= MIN_FOR_SCROLL && !prefersReducedMotion;
+
+    if (!animate) {
+        return (
+            <ul className="partners-carousel partners-carousel--static">
+                {partners.map((partner) => (
+                    <PartnerItem key={partner.id} partner={partner} />
+                ))}
+            </ul>
+        );
+    }
+
+    return (
+        <div className="partners-carousel" role="group" aria-label="Nos partenaires">
+            <ul className="partners-carousel__track">
+                {partners.map((partner) => (
+                    <PartnerItem key={partner.id} partner={partner} />
+                ))}
+                {partners.map((partner) => (
+                    <PartnerItem key={`dup-${partner.id}`} partner={partner} duplicated />
+                ))}
+            </ul>
+        </div>
+    );
+}

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -5,6 +5,7 @@ import type { HomeData } from "../types/api";
 import { ClubMap } from "../components/map/ClubMap";
 import { ArticleCard } from "../components/ui/Card";
 import { ArticleTitle } from "../components/ui/Title";
+import { PartnersCarousel } from "../components/partners/PartnersCarousel";
 import { Helmet } from "react-helmet-async";
 import { ErrorPage } from "./ErrorPage";
 
@@ -120,25 +121,7 @@ export function HomePage() {
                 <ArticleCard className="home-section home-partners">
 
                     {home?.partners.length ? (
-                            <div className="partners-grid">
-                                {home.partners.map((partner) => (
-                                    <a
-                                        key={partner.id}
-                                        href={partner.website_url ?? "#"}
-                                        target="_blank"
-                                        rel="noopener noreferrer"
-                                        className="partner-card"
-                                    >
-                                        {partner.logo_url && (
-                                            <img
-                                                src={partner.logo_url}
-                                                alt={partner.name ?? partner.nom ?? "Partenaire"}
-                                                className="partner-logo"
-                                            />
-                                        )}
-                                    </a>
-                                ))}
-                            </div>
+                        <PartnersCarousel partners={home.partners} />
                     ) : (
                         <p>Aucun partenaire</p>
                     )}

--- a/frontend/src/styles/partnersCarousel.css
+++ b/frontend/src/styles/partnersCarousel.css
@@ -1,0 +1,86 @@
+.partners-carousel {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+/* Rangee statique : peu de partenaires ou preference de mouvement reduit. */
+.partners-carousel--static {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 2rem;
+    align-items: center;
+    justify-content: center;
+}
+
+/* Piste animee : on masque les bords pour un fondu propre. */
+.partners-carousel:not(.partners-carousel--static) {
+    overflow: hidden;
+    -webkit-mask-image: linear-gradient(90deg, transparent, #000 8%, #000 92%, transparent);
+    mask-image: linear-gradient(90deg, transparent, #000 8%, #000 92%, transparent);
+}
+
+.partners-carousel__track {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    gap: 2rem;
+    width: max-content;
+    /* La piste = liste + copie (2x) : translater de -50% avance d'exactement
+       une liste, la boucle est donc invisible. */
+    animation: partners-scroll 40s linear infinite;
+}
+
+.partners-carousel:hover .partners-carousel__track,
+.partners-carousel:focus-within .partners-carousel__track {
+    animation-play-state: paused;
+}
+
+.partners-carousel__item {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.partners-carousel__link {
+    display: flex;
+    align-items: center;
+    border-radius: 8px;
+}
+
+.partners-carousel__link:focus-visible {
+    outline: 3px solid currentColor;
+    outline-offset: 4px;
+}
+
+.partners-carousel__logo {
+    height: 64px;
+    width: auto;
+    max-width: 170px;
+    /* Conserve les proportions : jamais de deformation. */
+    object-fit: contain;
+    display: block;
+}
+
+.partners-carousel__fallback {
+    font-weight: 600;
+    white-space: nowrap;
+    padding: 0 0.5rem;
+}
+
+@keyframes partners-scroll {
+    from {
+        transform: translateX(0);
+    }
+    to {
+        transform: translateX(-50%);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .partners-carousel__track {
+        animation: none;
+    }
+}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -53,6 +53,8 @@ export type Partner = {
     nom?: string;
     logo_url?: string | null;
     website_url?: string | null;
+    alt?: string | null;
+    order?: number | null;
 };
 
 export type WelcomeMessage = {


### PR DESCRIPTION
## LOT 1 — Carrousel infini des partenaires

Sur la page d'accueil, les partenaires actifs s'affichent dans un carrousel infini, fluide, responsive et accessible, à la place de la grille statique.

### Back
- **Migration** `partenaires` : `ordre`, `actif`, `alt`, `date_debut`, `date_fin` (nullables / à défaut) + backfill de l'ordre existant. Un partenariat terminé se **désactive** ou sort de sa fenêtre de dates au lieu d'être supprimé.
- **Modèle `Partenaire`** : scope `visible()` (actif + fenêtre de dates + tri par `ordre`) et invalidation du cache d'accueil à chaque écriture (création / modification / suppression).
- **API** `/public/home` et `/partenaires` : ne renvoient que les partenaires visibles, triés ; `PartnerResource` expose `alt` et `order`.
- **Admin partenaires** : champs `ordre` / `actif` / `alt` / dates avec aides en français, colonnes et tri de la grille.

### Front
- **`PartnersCarousel`** : défilement CSS continu (aucune dépendance JS lourde), boucle **sans saut** (liste dupliquée, copie en `aria-hidden` et non focusable), **pause au survol et au focus**, liens `rel="noopener noreferrer"`, texte alternatif, gestion du logo manquant/invalide (repli sur le nom), bascule en **liste statique** si peu de partenaires ou `prefers-reduced-motion`.

### Déploiement
```bash
php artisan migrate
```
Aucune dépendance ajoutée. Le contrat `home.partners` de l'API est conservé (rétrocompatible).

### Tests exécutés
- `npm run build` (frontend) : ✅ typecheck + vite.
- `php artisan test` : ✅ **175 passed** (2985 assertions), aucune régression.
- API vérifiée : 8 partenaires visibles, triés, champs `order`/`alt`.

### Tests manuels (visuels, à faire en recette)
- Défilement continu sans saut ; pause au survol / focus clavier.
- Logos non déformés ; responsive mobile / tablette / desktop.
- Navigation clavier : partenaires atteints, focus visible ; copies dupliquées non atteintes.
- `prefers-reduced-motion` → pas d'animation, liste statique.
- Admin : inactif / `date_fin` dépassée → masqué ; `ordre` → ré-ordonne.
- Cas 0 / 1‑2 / nombreux partenaires ; logo manquant → nom en repli.
