### PR TITLE
LOT 2 — Refonte visuelle d'OpenAdmin (charte BCJ37)

### DIFF
--- a/app/Admin/bootstrap.php
+++ b/app/Admin/bootstrap.php
@@ -6,6 +6,10 @@ use App\Admin\Extensions\Form\Ck5Decoupled;
 
 Form::extend('ck5', Ck5Decoupled::class);
 
+// Charte graphique BCJ37 (chargee apres les styles OpenAdmin pour surcharger
+// les variables Bootstrap). Voir public/css/admin-bcj.css.
+Admin::css('/css/admin-bcj.css');
+
 // Quill (CSS + JS)
 Admin::css('https://cdn.jsdelivr.net/npm/quill@1.3.7/dist/quill.snow.css');
 Admin::js('https://cdn.jsdelivr.net/npm/quill@1.3.7/dist/quill.min.js');

--- a/config/admin.php
+++ b/config/admin.php
@@ -13,7 +13,7 @@ return [
     | login page.
     |
     */
-    'name' => 'BCJ Admin',
+    'name' => 'BCJ37 · Administration',
 
     /*
     |--------------------------------------------------------------------------
@@ -24,7 +24,7 @@ return [
     | `img` tag, eg '<img src="http://logo-url" alt="Admin logo">'.
     |
     */
-    'logo' => '<b>BCJ</b> Admin',
+    'logo' => '<b>BCJ37</b> Administration',
 
     /*
     |--------------------------------------------------------------------------
@@ -87,7 +87,7 @@ return [
     | Html title for all pages.
     |
     */
-    'title' => 'Admin',
+    'title' => 'BCJ37 Admin',
 
     /*
     |--------------------------------------------------------------------------

--- a/public/css/admin-bcj.css
+++ b/public/css/admin-bcj.css
@@ -1,0 +1,146 @@
+/*
+ * Charte graphique BCJ37 pour l'administration OpenAdmin.
+ *
+ * Approche volontairement basee sur la surcharge des variables Bootstrap 5
+ * exposees par OpenAdmin (--bs-primary, --primary-color, ...) plus quelques
+ * regles ciblees. Aucun fichier du package n'est modifie : une mise a jour
+ * d'OpenAdmin n'ecrasera pas ce theme.
+ *
+ * Palette reprise du site public (frontend React) :
+ *   bleu de marque #0e4daa, degrade signature rose -> bleu.
+ */
+
+:root {
+    --bcj-blue: #0e4daa;
+    --bcj-blue-dark: #0a2f68;
+    --bcj-blue-darker: #08234f;
+    --bcj-pink: #ff65a3;
+    --bcj-gradient: linear-gradient(94deg, #ff65a3, #0e4daa);
+
+    /* Surcharge de la couleur primaire Bootstrap : boutons, liens, etats actifs. */
+    --bs-primary: #0e4daa;
+    --bs-primary-rgb: 14, 77, 170;
+    --primary-color: #0e4daa;
+    --bs-link-color: #0e4daa;
+    --bs-link-color-rgb: 14, 77, 170;
+    --bs-link-hover-color: #0a2f68;
+}
+
+/* ------------------------------------------------------------------ */
+/* Barre laterale                                                     */
+/* ------------------------------------------------------------------ */
+
+.sidebar.bg-semi-dark {
+    background: var(--bcj-blue-darker) !important;
+}
+
+/* Zone marque (logo) : degrade signature du club. */
+.navbar-brand.bg-semi-dark {
+    background: var(--bcj-gradient) !important;
+    color: #fff !important;
+}
+
+.sidebar a {
+    color: #d3ddf0;
+}
+
+.sidebar a:hover,
+.sidebar a:focus {
+    color: #fff;
+    background: rgba(255, 255, 255, 0.08);
+}
+
+/* Etat actif : fond + barre rose (l'info n'est pas portee par la seule couleur). */
+.sidebar a.active,
+.sidebar li.active > a {
+    color: #fff;
+    background: rgba(255, 255, 255, 0.12);
+    border-left: 3px solid var(--bcj-pink);
+}
+
+/* ------------------------------------------------------------------ */
+/* Barre superieure                                                   */
+/* ------------------------------------------------------------------ */
+
+.custom-navbar.bg-white {
+    border-bottom: 2px solid var(--bcj-blue);
+}
+
+/* ------------------------------------------------------------------ */
+/* Boutons                                                            */
+/* ------------------------------------------------------------------ */
+
+.btn-primary {
+    --bs-btn-bg: var(--bcj-blue);
+    --bs-btn-border-color: var(--bcj-blue);
+    --bs-btn-hover-bg: var(--bcj-blue-dark);
+    --bs-btn-hover-border-color: var(--bcj-blue-dark);
+    --bs-btn-active-bg: var(--bcj-blue-dark);
+    --bs-btn-active-border-color: var(--bcj-blue-dark);
+}
+
+/* ------------------------------------------------------------------ */
+/* Accessibilite : focus toujours visible                            */
+/* ------------------------------------------------------------------ */
+
+a:focus-visible,
+.btn:focus-visible,
+.page-link:focus,
+.form-control:focus,
+.form-select:focus,
+.custom-select:focus {
+    outline: 2px solid var(--bcj-blue);
+    outline-offset: 2px;
+}
+
+.form-control:focus,
+.form-select:focus {
+    border-color: var(--bcj-blue);
+    box-shadow: 0 0 0 0.2rem rgba(14, 77, 170, 0.2);
+}
+
+/* ------------------------------------------------------------------ */
+/* Cartes, tableaux, pagination                                       */
+/* ------------------------------------------------------------------ */
+
+.card,
+.box {
+    border-top: 3px solid var(--bcj-blue);
+}
+
+.table thead th {
+    color: var(--bcj-blue-dark);
+    border-bottom: 2px solid var(--bcj-blue);
+}
+
+.page-item.active .page-link {
+    background-color: var(--bcj-blue);
+    border-color: var(--bcj-blue);
+}
+
+.page-link {
+    color: var(--bcj-blue);
+}
+
+/* Alertes : rappel de la nature par un liseret a gauche (pas que la couleur). */
+.alert {
+    border-left-width: 4px;
+}
+
+/* ------------------------------------------------------------------ */
+/* Ecran de connexion                                                 */
+/* ------------------------------------------------------------------ */
+
+body.bg-light {
+    background: var(--bcj-gradient) !important;
+    min-height: 100vh;
+}
+
+body.bg-light h1 a {
+    color: #fff !important;
+    font-weight: 700;
+}
+
+body.bg-light .bg-body {
+    border-top: 4px solid var(--bcj-blue);
+}

--- a/resources/views/vendor/admin/login.blade.php
+++ b/resources/views/vendor/admin/login.blade.php
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="utf-8">
+		<meta http-equiv="X-UA-Compatible" content="IE=edge">
+		<title>{{config('admin.title')}} | {{ __('admin.login') }}</title>
+		<meta content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" name="viewport">
+
+		@if(!is_null($favicon = Admin::favicon()))
+		<link rel="shortcut icon" href="{{$favicon}}">
+		@endif
+
+		<link rel="stylesheet" href="{{ Admin::asset("open-admin/css/styles.css")}}">
+		{{-- Charte BCJ37 : voir public/css/admin-bcj.css --}}
+		<link rel="stylesheet" href="{{ asset('css/admin-bcj.css') }}">
+		<script src="{{ Admin::asset("bootstrap5/bootstrap.bundle.min.js")}}"></script>
+
+	</head>
+	<body class="bg-light" @if(config('admin.login_background_image'))style="background: url({{config('admin.login_background_image')}}) no-repeat;background-size: cover;"@endif>
+		<div class="d-flex justify-content-center align-items-center h-100">
+			<div class="container m-4" style="max-width:400px;">
+				<h1 class="text-center mb-3 h2"><a class="text-decoration-none text-dark" href="{{ admin_url('/') }}">{{config('admin.name')}}</a></h1>
+				<div class="bg-body p-4 shadow-sm rounded-3">
+
+					@if($errors->has('attempts'))
+						<div class="alert alert-danger m-0 text-center">{{$errors->first('attempts')}}</div>
+					@else
+
+					<form action="{{ admin_url('auth/login') }}" method="post">
+
+						<input type="hidden" name="_token" value="{{ csrf_token() }}">
+						<div class="mb-3">
+
+							@if($errors->has('username'))
+								<div class="alert alert-danger">{{$errors->first('username')}}</div>
+							@endif
+
+							<label for="username" class="form-label">{{ __('admin.username') }}</label>
+							<div class="input-group mb-3">
+								<span class="input-group-text"><i class="icon-user"></i></span>
+								<input type="text" class="form-control" placeholder="{{ __('admin.username') }}" name="username" id="username" value="{{ old('username') }}" required>
+							</div>
+						</div>
+
+						<div class="mb-3">
+							<label for="password" class="form-label">{{ __('admin.password') }}</label>
+							<div class="input-group mb-3">
+								<span class="input-group-text"><i class="icon-eye"></i></span>
+								<input type="password" class="form-control" placeholder="{{ __('admin.password') }}" name="password" id="password" required>
+							</div>
+
+							@if($errors->has('password'))
+								<div class="alert alert-danger">{{$errors->first('password') }}</div>
+							@endif
+						</div>
+
+						@if(config('admin.auth.remember'))
+						<div class="mb-3 form-check">
+							<input type="checkbox" class="form-check-input" name="remember" id="remember" value="1"  {{ (old('remember')) ? 'checked="checked"' : '' }}>
+							<label class="form-check-label" for="remember">{{ __('admin.remember_me') }}</label>
+						</div>
+						@endif
+
+						<div class="clearfix">
+							<button type="submit" class="btn float-end btn-primary">{{ __('admin.login') }}</button>
+						</div>
+
+					</form>
+					@endif
+				</div>
+			</div>
+		</div>
+	</body>
+</html>


### PR DESCRIPTION
## LOT 2 — Refonte visuelle d'OpenAdmin

L'administration reprend l'identité graphique du site public BCJ37 (bleu `#0e4daa`, dégradé signature rose → bleu, polices system-ui), **sans modifier le package** : une mise à jour d'OpenAdmin n'écrasera pas ce thème.

### Approche
OpenAdmin est basé sur Bootstrap 5 et expose des variables CSS (`--bs-primary`, `--primary-color`…). Le thème **surcharge ces variables** + quelques règles ciblées, plutôt que de dupliquer du CSS fragile.

### Fichiers
- **`public/css/admin-bcj.css`** : barre latérale bleu profond, zone marque en dégradé, boutons / liens / pagination en bleu de marque, en-têtes de tableaux, cartes, **focus toujours visible**, écran de connexion en dégradé.
- **`app/Admin/bootstrap.php`** : chargement de la feuille **après** les styles du package (pour surcharger les variables).
- **`resources/views/vendor/admin/login.blade.php`** : surcharge minimale (ajout du lien CSS + bouton de connexion en action principale).
- **`config/admin.php`** : nom / logo / titre explicitement « BCJ37 ».

### Accessibilité
- Focus visible conservé (contour bleu), contrastes tenus (texte clair sur bleu profond, blanc sur `#0e4daa`).
- L'état actif du menu n'est **pas** porté par la seule couleur (fond + liseré rose).

### Tests exécutés
- CSS servie : `/css/admin-bcj.css` → HTTP 200 (`text/css`).
- Page de connexion : charge la charte + nom BCJ37 + bouton primaire.
- Page admin authentifiée : charte injectée (après les styles du package).
- `php artisan test` : **175 passed**, aucune régression.

### Tests manuels (visuels, à faire en recette)
- Connexion, menu latéral, barre supérieure, cartes, tableaux, formulaires, boutons, badges, alertes, pagination.
- États focus au clavier, contrastes sur écran moyen, distinction actions principales / secondaires / destructives.

### Déploiement
Aucune migration ni dépendance. Vider les caches admin si nécessaire (`php artisan view:clear`).
