### PR TITLE
LOT 3 — Dashboard analytique du club

### DIFF
--- a/app/Admin/Controllers/HomeController.php
+++ b/app/Admin/Controllers/HomeController.php
@@ -3,19 +3,18 @@
 namespace App\Admin\Controllers;
 
 use App\Http\Controllers\Controller;
-use OpenAdmin\Admin\Admin;
-use OpenAdmin\Admin\Controllers\Dashboard;
-use OpenAdmin\Admin\Layout\Column;
+use App\Services\ClubDashboardService;
 use OpenAdmin\Admin\Layout\Content;
-use OpenAdmin\Admin\Layout\Row;
 
 class HomeController extends Controller
 {
-    public function index(Content $content)
+    public function index(Content $content, ClubDashboardService $dashboard)
     {
         return $content
             ->title('Tableau de bord')
-            ->description('Bienvenue dans l\'administration')
-            ->row(view('admin.custom_dashboard'));
+            ->description('Vue d\'ensemble du club')
+            ->row(view('admin.dashboard.index', [
+                'metrics' => $dashboard->metrics(),
+            ]));
     }
 }

--- a/app/Services/ClubDashboardService.php
+++ b/app/Services/ClubDashboardService.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\CalendarEvent;
+use App\Models\CueScoreRankingFetch;
+use App\Models\Document;
+use App\Models\Licencies;
+use App\Models\LicenseImportBatch;
+use App\Models\Partenaire;
+use App\Models\Post;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Agrege les indicateurs du tableau de bord d'administration.
+ *
+ * Regle stricte : uniquement des donnees reellement presentes en base. Les
+ * indicateurs non disponibles (repartition des licencies, brouillons, cotisations)
+ * ne sont pas approximes ici : la vue les signale comme « non encore suivis ».
+ *
+ * Toutes les requetes sont agregees ou bornees (pas de chargement complet en
+ * memoire, pas de N+1). Le service pourra ulterieurement filtrer par saison
+ * lorsque les entites concernees porteront cette information.
+ */
+class ClubDashboardService
+{
+    private const DISCIPLINES = [
+        1 => 'Blackball',
+        2 => 'Carambole',
+        3 => 'Snooker',
+        4 => 'Américain',
+    ];
+
+    private const EXPIRY_WINDOW_DAYS = 30;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function metrics(): array
+    {
+        return [
+            'articles' => $this->articles(),
+            'documents' => $this->documents(),
+            'partenaires' => $this->partenaires(),
+            'licencies' => $this->licencies(),
+            'evenements' => $this->evenements(),
+            'technique' => $this->technique(),
+        ];
+    }
+
+    private function articles(): array
+    {
+        $byDiscipline = [];
+        $rows = Post::query()
+            ->select('discipline', DB::raw('count(*) as total'))
+            ->groupBy('discipline')
+            ->pluck('total', 'discipline');
+
+        foreach ($rows as $code => $total) {
+            $name = self::DISCIPLINES[(int) $code] ?? 'Le Club';
+            $byDiscipline[$name] = ($byDiscipline[$name] ?? 0) + (int) $total;
+        }
+        arsort($byDiscipline);
+
+        return [
+            'total' => Post::count(),
+            'latest' => Post::query()->orderByDesc('created_at')->first(['id', 'title', 'created_at']),
+            'recentlyUpdated' => Post::query()
+                ->orderByDesc('updated_at')
+                ->limit(5)
+                ->get(['id', 'title', 'updated_at']),
+            'byDiscipline' => $byDiscipline,
+        ];
+    }
+
+    private function documents(): array
+    {
+        return [
+            'total' => Document::count(),
+        ];
+    }
+
+    private function partenaires(): array
+    {
+        return [
+            'active' => Partenaire::visible()->count(),
+            'expiringSoon' => Partenaire::query()
+                ->whereNotNull('date_fin')
+                ->whereDate('date_fin', '>=', now()->toDateString())
+                ->whereDate('date_fin', '<=', now()->addDays(self::EXPIRY_WINDOW_DAYS)->toDateString())
+                ->orderBy('date_fin')
+                ->get(['id', 'titre', 'date_fin']),
+        ];
+    }
+
+    private function licencies(): array
+    {
+        // Seul le total est disponible : la table licencies ne porte ni
+        // discipline, ni categorie, ni statut. Les repartitions sont donc
+        // signalees « non suivies » cote vue.
+        return [
+            'total' => Licencies::count(),
+        ];
+    }
+
+    private function evenements(): array
+    {
+        $today = now()->toDateString();
+
+        return [
+            'upcomingCount' => CalendarEvent::query()->whereDate('date_debut', '>=', $today)->count(),
+            'upcoming' => CalendarEvent::query()
+                ->whereDate('date_debut', '>=', $today)
+                ->orderBy('date_debut')
+                ->limit(5)
+                ->get(['id', 'titre', 'date_debut', 'lieu']),
+        ];
+    }
+
+    private function technique(): array
+    {
+        return [
+            'lastImport' => LicenseImportBatch::query()->orderByDesc('started_at')->first(),
+            'failedImports' => LicenseImportBatch::query()->where('status', 'failed')->count(),
+            'cuescoreErrors' => CueScoreRankingFetch::query()->where('status', 'failed')->count(),
+        ];
+    }
+}

--- a/resources/views/admin/dashboard/index.blade.php
+++ b/resources/views/admin/dashboard/index.blade.php
@@ -1,0 +1,216 @@
+@php
+    use Illuminate\Support\Carbon;
+    use Illuminate\Support\Str;
+
+    $articles = $metrics['articles'];
+    $documents = $metrics['documents'];
+    $partenaires = $metrics['partenaires'];
+    $licencies = $metrics['licencies'];
+    $evenements = $metrics['evenements'];
+    $technique = $metrics['technique'];
+
+    $maxDiscipline = collect($articles['byDiscipline'])->max() ?: 1;
+
+    $importStatus = $technique['lastImport']?->status;
+    $importStatusValue = is_object($importStatus) ? ($importStatus->value ?? (string) $importStatus) : (string) ($importStatus ?? '');
+@endphp
+
+<style>
+    .dashboard-bcj .card { border-radius: 10px; }
+    .dashboard-bcj .stat-value { font-size: 2rem; font-weight: 700; line-height: 1; }
+    .dashboard-bcj .muted-note { font-size: .8rem; color: #6c757d; }
+    .dashboard-bcj .bar-row { display: flex; align-items: center; gap: .5rem; margin-bottom: .4rem; }
+    .dashboard-bcj .bar-label { flex: 0 0 90px; font-size: .85rem; }
+    .dashboard-bcj .bar-track { flex: 1; background: #eef1f6; border-radius: 6px; height: 14px; overflow: hidden; }
+    .dashboard-bcj .bar-fill { height: 100%; background: linear-gradient(90deg, #ff65a3, #0e4daa); }
+    .dashboard-bcj .bar-count { flex: 0 0 28px; text-align: right; font-size: .8rem; color: #495057; }
+    .dashboard-bcj .list-line { display: flex; justify-content: space-between; gap: .5rem; padding: .3rem 0; border-bottom: 1px solid #f0f1f4; }
+    .dashboard-bcj .list-line:last-child { border-bottom: 0; }
+</style>
+
+<div class="dashboard-bcj">
+
+    {{-- Raccourcis vers les principales actions --}}
+    <div class="d-flex flex-wrap gap-2 mb-4">
+        <a class="btn btn-primary btn-sm" href="{{ admin_url('posts/create') }}"><i class="icon-plus"></i> Nouvel article</a>
+        <a class="btn btn-outline-primary btn-sm" href="{{ admin_url('partenaires/create') }}"><i class="icon-plus"></i> Nouveau partenaire</a>
+        <a class="btn btn-outline-primary btn-sm" href="{{ admin_url('documents/create') }}"><i class="icon-plus"></i> Nouveau document</a>
+        <a class="btn btn-outline-secondary btn-sm" href="{{ admin_url('license-import/batches') }}">Imports des licenciés</a>
+    </div>
+
+    {{-- Cartes chiffres cles : chaque carte mene a sa section --}}
+    <div class="row g-3 mb-3">
+        <div class="col-6 col-lg-3">
+            <div class="card h-100 position-relative">
+                <div class="card-body">
+                    <div class="text-muted small text-uppercase">Articles</div>
+                    <div class="stat-value">{{ $articles['total'] }}</div>
+                    @if($articles['latest'])
+                        <div class="muted-note">Dernier : {{ Str::limit($articles['latest']->title, 34) }}</div>
+                    @endif
+                    <a class="stretched-link" href="{{ admin_url('posts') }}" aria-label="Voir les articles"></a>
+                </div>
+            </div>
+        </div>
+
+        <div class="col-6 col-lg-3">
+            <div class="card h-100 position-relative">
+                <div class="card-body">
+                    <div class="text-muted small text-uppercase">Documents</div>
+                    <div class="stat-value">{{ $documents['total'] }}</div>
+                    <div class="muted-note">Fichiers mis a disposition</div>
+                    <a class="stretched-link" href="{{ admin_url('documents') }}" aria-label="Voir les documents"></a>
+                </div>
+            </div>
+        </div>
+
+        <div class="col-6 col-lg-3">
+            <div class="card h-100 position-relative">
+                <div class="card-body">
+                    <div class="text-muted small text-uppercase">Partenaires actifs</div>
+                    <div class="stat-value">{{ $partenaires['active'] }}</div>
+                    @if($partenaires['expiringSoon']->isNotEmpty())
+                        <div class="muted-note text-warning">
+                            {{ $partenaires['expiringSoon']->count() }} arrive(nt) a expiration sous 30 j
+                        </div>
+                    @else
+                        <div class="muted-note">Aucune expiration proche</div>
+                    @endif
+                    <a class="stretched-link" href="{{ admin_url('partenaires') }}" aria-label="Voir les partenaires"></a>
+                </div>
+            </div>
+        </div>
+
+        <div class="col-6 col-lg-3">
+            <div class="card h-100 position-relative">
+                <div class="card-body">
+                    <div class="text-muted small text-uppercase">Licencies</div>
+                    <div class="stat-value">{{ $licencies['total'] }}</div>
+                    <div class="muted-note">Repartitions par discipline / categorie : non encore suivies</div>
+                    <a class="stretched-link" href="{{ admin_url('licencies') }}" aria-label="Voir les licencies"></a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row g-3">
+        {{-- Prochains evenements --}}
+        <div class="col-lg-4">
+            <div class="card h-100">
+                <div class="card-body">
+                    <h6 class="card-title">Prochains evenements</h6>
+                    @forelse($evenements['upcoming'] as $event)
+                        <div class="list-line">
+                            <span>{{ Str::limit($event->titre, 28) }}</span>
+                            <span class="text-muted small">{{ Carbon::parse($event->date_debut)->format('d/m/Y') }}</span>
+                        </div>
+                    @empty
+                        <p class="muted-note mb-0">Aucun evenement a venir enregistre.</p>
+                    @endforelse
+                </div>
+            </div>
+        </div>
+
+        {{-- Suivi technique --}}
+        <div class="col-lg-4">
+            <div class="card h-100">
+                <div class="card-body">
+                    <h6 class="card-title">Suivi technique</h6>
+                    <div class="list-line">
+                        <span>Dernier import licencies</span>
+                        <span class="text-muted small">
+                            @if($technique['lastImport'])
+                                {{ $importStatusValue }} · {{ Carbon::parse($technique['lastImport']->started_at)->format('d/m/Y') }}
+                            @else
+                                aucun
+                            @endif
+                        </span>
+                    </div>
+                    <div class="list-line">
+                        <span>Imports en echec</span>
+                        <span>
+                            @if($technique['failedImports'] > 0)
+                                <span class="badge bg-danger">{{ $technique['failedImports'] }}</span>
+                            @else
+                                <span class="badge bg-success">0</span>
+                            @endif
+                        </span>
+                    </div>
+                    <div class="list-line">
+                        <span>Synchros CueScore en erreur</span>
+                        <span>
+                            @if($technique['cuescoreErrors'] > 0)
+                                <span class="badge bg-danger">{{ $technique['cuescoreErrors'] }}</span>
+                            @else
+                                <span class="badge bg-success">0</span>
+                            @endif
+                        </span>
+                    </div>
+                    <a class="small" href="{{ admin_url('license-import/batches') }}">Voir les imports</a>
+                </div>
+            </div>
+        </div>
+
+        {{-- Articles par discipline (repond a : quelle discipline publie le plus) --}}
+        <div class="col-lg-4">
+            <div class="card h-100">
+                <div class="card-body">
+                    <h6 class="card-title">Articles par discipline</h6>
+                    @forelse($articles['byDiscipline'] as $name => $count)
+                        <div class="bar-row">
+                            <span class="bar-label">{{ $name }}</span>
+                            <span class="bar-track">
+                                <span class="bar-fill" style="width: {{ round($count / $maxDiscipline * 100) }}%"></span>
+                            </span>
+                            <span class="bar-count">{{ $count }}</span>
+                        </div>
+                    @empty
+                        <p class="muted-note mb-0">Aucun article.</p>
+                    @endforelse
+                </div>
+            </div>
+        </div>
+    </div>
+
+    {{-- Contenus recemment modifies --}}
+    <div class="row g-3 mt-1">
+        <div class="col-lg-6">
+            <div class="card h-100">
+                <div class="card-body">
+                    <h6 class="card-title">Articles recemment modifies</h6>
+                    @forelse($articles['recentlyUpdated'] as $post)
+                        <div class="list-line">
+                            <a href="{{ admin_url('posts/' . $post->id . '/edit') }}">{{ Str::limit($post->title, 40) }}</a>
+                            <span class="text-muted small">{{ Carbon::parse($post->updated_at)->format('d/m/Y') }}</span>
+                        </div>
+                    @empty
+                        <p class="muted-note mb-0">Aucun article.</p>
+                    @endforelse
+                </div>
+            </div>
+        </div>
+
+        <div class="col-lg-6">
+            <div class="card h-100">
+                <div class="card-body">
+                    <h6 class="card-title">Partenaires arrivant a expiration</h6>
+                    @forelse($partenaires['expiringSoon'] as $partenaire)
+                        <div class="list-line">
+                            <a href="{{ admin_url('partenaires/' . $partenaire->id . '/edit') }}">{{ Str::limit($partenaire->titre, 34) }}</a>
+                            <span class="text-muted small">{{ Carbon::parse($partenaire->date_fin)->format('d/m/Y') }}</span>
+                        </div>
+                    @empty
+                        <p class="muted-note mb-0">Aucun partenariat n'arrive a expiration dans les 30 jours.</p>
+                    @endforelse
+                </div>
+            </div>
+        </div>
+    </div>
+
+    {{-- Indicateurs non encore suivis (honnete : pas de chiffre invente) --}}
+    <p class="muted-note mt-3">
+        Non encore suivis (a activer plus tard) : brouillons et publications programmees des articles,
+        cotisations, repartition detaillee des licencies.
+    </p>
+
+</div>


### PR DESCRIPTION
## LOT 3 — Dashboard analytique du club

La page d'accueil de l'administration devient un véritable tableau de bord pour les dirigeants, **basé uniquement sur des données réelles**. Les indicateurs non disponibles sont signalés « non encore suivis » plutôt qu'approximés (aucune donnée fictive).

### Contenu (données réelles)
- **Cartes chiffres** (mènent à leur section) : articles, documents, partenaires actifs (+ alerte expiration < 30 j), licenciés.
- **Prochains événements** (`calendar_events`, à venir) — sinon « aucun événement à venir ».
- **Suivi technique** : dernier import licenciés (statut + date), imports en échec, synchros CueScore en erreur.
- **Articles par discipline** : mini-graphe CSS (répond à « quelle discipline publie le plus »), sans dépendance de graphes.
- **Articles récemment modifiés** et **partenaires proches de l'expiration**.
- **Raccourcis** : nouvel article / partenaire / document, imports licenciés.

### Explicitement « non suivis » (honnête)
Brouillons & publications programmées (posts sans statut — arrive au LOT 4), cotisations, répartition détaillée des licenciés (la table `licencies` ne porte ni discipline ni catégorie).

### Architecture & performance
- `ClubDashboardService` : requêtes **agrégées / bornées** (pas de N+1, pas de chargement complet en mémoire). Structuré pour un futur filtrage par saison.
- `HomeController` mis à jour ; vue `admin.dashboard.index`.

### Tests exécutés
- Service vérifié : articles 48, documents 21, partenaires 8, licenciés 116, événements à venir 0, imports en échec 9 ; répartition par discipline correcte (mappée).
- `/admin` rendu : HTTP 200, sections présentes.
- `php artisan test` : **175 passed**, aucune régression.

### Tests manuels (recette)
Se connecter, vérifier la lisibilité des cartes, que chaque carte mène à sa section, l'affichage des listes vides (« aucun … »), les badges de suivi technique.

### Déploiement
Aucune migration ni dépendance.
