### PR TITLE
LOT 4 — Éditeur d'articles : nettoyage HTML serveur (sécurité)

### DIFF
--- a/app/Admin/Controllers/AdminPostController.php
+++ b/app/Admin/Controllers/AdminPostController.php
@@ -189,8 +189,12 @@ class AdminPostController extends AdminController
         $form->saving(function ($form) {
             $model = $form->model();
 
+            // Nettoyage serveur du HTML de l'article (liste blanche stricte)
+            // avant stockage : aucun script, style ou balise non autorisee.
+            $form->content = \App\Support\HtmlSanitizer::post($form->content);
+
             $model->slug = Str::slug($form->title);
-            $model->excerpt = Str::limit(strip_tags($form->content), 150);
+            $model->excerpt = Str::limit(strip_tags((string) $form->content), 150);
 
             if (!empty($form->video)) {
                 $model->thumbnail = null;

--- a/app/Admin/Extensions/Form/Ck5Decoupled.php
+++ b/app/Admin/Extensions/Form/Ck5Decoupled.php
@@ -42,19 +42,18 @@ class Ck5Decoupled extends Textarea
 
   // --- Toolbar HTML (style "décorrélé" comme CKEditor) ---
   // Tu peux ajuster les groupes/boutons en fonction de tes besoins.
+  // Barre d'outils volontairement limitee aux formats autorises et surs :
+  // pas de police, taille, couleur ni indentation arbitraires (le contenu est
+  // de toute facon nettoye cote serveur par liste blanche). Titres bornes a
+  // H2-H4 (le H1 est reserve au titre de l'article).
   toolbarDom.innerHTML = `
     <span class="ql-formats">
       <select class="ql-header">
         <option selected></option>
-        <option value="1"></option>
         <option value="2"></option>
         <option value="3"></option>
         <option value="4"></option>
-        <option value="5"></option>
-        <option value="6"></option>
       </select>
-      <select class="ql-font"></select>
-      <select class="ql-size"></select>
     </span>
     <span class="ql-formats">
       <button class="ql-bold"></button>
@@ -64,14 +63,10 @@ class Ck5Decoupled extends Textarea
     </span>
     <span class="ql-formats">
       <button class="ql-link"></button>
-      <select class="ql-color"></select>
-      <select class="ql-background"></select>
     </span>
     <span class="ql-formats">
       <button class="ql-list" value="ordered"></button>
       <button class="ql-list" value="bullet"></button>
-      <button class="ql-indent" value="-1"></button>
-      <button class="ql-indent" value="+1"></button>
     </span>
     <span class="ql-formats">
       <button class="ql-clean"></button>

--- a/app/Http/Resources/IndexResource.php
+++ b/app/Http/Resources/IndexResource.php
@@ -4,6 +4,7 @@ namespace App\Http\Resources;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use App\Support\HtmlSanitizer;
 
 class IndexResource extends JsonResource
 {
@@ -15,7 +16,7 @@ class IndexResource extends JsonResource
     public function toArray(Request $request): array
     {
         return [
-            'content' => $this->content ?? null,
+            'content' => HtmlSanitizer::post($this->content ?? null),
         ];
     }
 }

--- a/app/Http/Resources/PostResource.php
+++ b/app/Http/Resources/PostResource.php
@@ -5,6 +5,7 @@ namespace App\Http\Resources;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 use App\Support\DisciplineMapper;
+use App\Support\HtmlSanitizer;
 
 class PostResource extends JsonResource
 {
@@ -19,8 +20,8 @@ class PostResource extends JsonResource
             'id' => $this->id,
             'title' => $this->title,
             'slug' => $this->slug,
-            'excerpt' => $this->excerpt,
-            'content' => $this->content,
+            'excerpt' => HtmlSanitizer::post($this->excerpt),
+            'content' => HtmlSanitizer::post($this->content),
             'discipline' => DisciplineMapper::slugFromId($this->discipline),
             'discipline_id' => $this->discipline,
             'year' => $this->year,

--- a/app/Support/HtmlSanitizer.php
+++ b/app/Support/HtmlSanitizer.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Support;
+
+/**
+ * Nettoyage du HTML des contenus editoriaux (articles, message d'accueil).
+ *
+ * Le frontend React rend ces contenus en HTML brut (dangerouslySetInnerHTML) :
+ * ils doivent donc etre nettoyes cote serveur selon une liste blanche stricte
+ * (profil « post » de config/purifier.php) avant d'etre exposes par l'API.
+ *
+ * Le nettoyage est applique a la sortie (Resources) : il couvre l'ensemble des
+ * articles existants sans modifier la base et reste donc totalement reversible.
+ */
+class HtmlSanitizer
+{
+    public static function post(?string $html): ?string
+    {
+        if ($html === null || trim($html) === '') {
+            return $html;
+        }
+
+        return clean($html, 'post');
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "laravel/tinker": "^2.8",
         "maatwebsite/excel": "^3.1",
         "mbezhanov/faker-provider-collection": "^2.0",
+        "mews/purifier": "^3.4",
         "mpdf/mpdf": "^8.2",
         "open-admin-ext/helpers": "^1.0",
         "open-admin-org/open-admin": "^1.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "da8e15ad6ca794d8e6ce029bf977f3f5",
+    "content-hash": "872d10b93d9d7c354a652e44c562ed74",
     "packages": [
         {
             "name": "brick/math",
@@ -3103,6 +3103,84 @@
                 "source": "https://github.com/mbezhanov/faker-provider-collection/tree/2.0.2"
             },
             "time": "2023-12-26T14:31:52+00:00"
+        },
+        {
+            "name": "mews/purifier",
+            "version": "3.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mewebstudio/Purifier.git",
+                "reference": "b2705cc6c832ce7229373418e191d71b6c037841"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mewebstudio/Purifier/zipball/b2705cc6c832ce7229373418e191d71b6c037841",
+                "reference": "b2705cc6c832ce7229373418e191d71b6c037841",
+                "shasum": ""
+            },
+            "require": {
+                "ezyang/htmlpurifier": "^4.16.0",
+                "illuminate/config": "^5.8|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+                "illuminate/filesystem": "^5.8|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+                "illuminate/support": "^5.8|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+                "php": "^7.2|^8.0"
+            },
+            "require-dev": {
+                "graham-campbell/testbench": "^3.2|^5.5.1|^6.1",
+                "mockery/mockery": "^1.3.3",
+                "phpunit/phpunit": "^8.0|^9.0|^10.0"
+            },
+            "suggest": {
+                "laravel/framework": "To test the Laravel bindings",
+                "laravel/lumen-framework": "To test the Lumen bindings"
+            },
+            "type": "package",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Purifier": "Mews\\Purifier\\Facades\\Purifier"
+                    },
+                    "providers": [
+                        "Mews\\Purifier\\PurifierServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "Mews\\Purifier\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Muharrem ERİN",
+                    "email": "me@mewebstudio.com",
+                    "homepage": "https://github.com/mewebstudio",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Laravel 5/6/7/8/9/10 HtmlPurifier Package",
+            "homepage": "https://github.com/mewebstudio/purifier",
+            "keywords": [
+                "Laravel Purifier",
+                "Laravel Security",
+                "Purifier",
+                "htmlpurifier",
+                "laravel HtmlPurifier",
+                "security",
+                "xss"
+            ],
+            "support": {
+                "issues": "https://github.com/mewebstudio/Purifier/issues",
+                "source": "https://github.com/mewebstudio/Purifier/tree/3.4.4"
+            },
+            "time": "2026-04-15T16:41:08+00:00"
         },
         {
             "name": "monolog/monolog",

--- a/config/purifier.php
+++ b/config/purifier.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Ok, glad you are here
+ * first we get a config instance, and set the settings
+ * $config = HTMLPurifier_Config::createDefault();
+ * $config->set('Core.Encoding', $this->config->get('purifier.encoding'));
+ * $config->set('Cache.SerializerPath', $this->config->get('purifier.cachePath'));
+ * if ( ! $this->config->get('purifier.finalize')) {
+ *     $config->autoFinalize = false;
+ * }
+ * $config->loadArray($this->getConfig());
+ *
+ * You must NOT delete the default settings
+ * anything in settings should be compacted with params that needed to instance HTMLPurifier_Config.
+ *
+ * @link http://htmlpurifier.org/live/configdoc/plain.html
+ */
+
+return [
+    'encoding'           => 'UTF-8',
+    'finalize'           => true,
+    'ignoreNonStrings'   => false,
+    'cachePath'          => storage_path('app/purifier'),
+    'cacheFileMode'      => 0755,
+    'settings'      => [
+        'default' => [
+            'HTML.Doctype'             => 'HTML 4.01 Transitional',
+            'HTML.Allowed'             => 'div,b,strong,i,em,u,a[href|title],ul,ol,li,p[style],br,span[style],img[width|height|alt|src]',
+            'CSS.AllowedProperties'    => 'font,font-size,font-weight,font-style,font-family,text-decoration,padding-left,color,background-color,text-align',
+            'AutoFormat.AutoParagraph' => true,
+            'AutoFormat.RemoveEmpty'   => true,
+        ],
+        // Profil des contenus d'articles rendus en HTML par le frontend React.
+        // Liste blanche stricte : structure de base + liens surs. Aucun style
+        // inline, aucune couleur/police arbitraire, aucun script, iframe ni image
+        // (le HTML est nettoye avant d'etre renvoye au front, cf. HtmlSanitizer).
+        'post' => [
+            'HTML.Doctype'           => 'HTML 4.01 Transitional',
+            'HTML.Allowed'           => 'p,br,strong,b,em,i,u,h1,h2,h3,h4,ul,ol,li,a[href|title],blockquote,pre,code',
+            'HTML.TargetBlank'       => true,
+            'URI.AllowedSchemes'     => ['http' => true, 'https' => true, 'mailto' => true],
+            'AutoFormat.RemoveEmpty' => true,
+            'Cache.DefinitionImpl'   => null,
+        ],
+        'test'    => [
+            'Attr.EnableID' => 'true',
+        ],
+        "youtube" => [
+            "HTML.SafeIframe"      => 'true',
+            "URI.SafeIframeRegexp" => "%^(http://|https://|//)(www.youtube.com/embed/|player.vimeo.com/video/)%",
+        ],
+        'custom_definition' => [
+            'id'  => 'html5-definitions',
+            'rev' => 1,
+            'debug' => false,
+            'elements' => [
+                // http://developers.whatwg.org/sections.html
+                ['section', 'Block', 'Flow', 'Common'],
+                ['nav',     'Block', 'Flow', 'Common'],
+                ['article', 'Block', 'Flow', 'Common'],
+                ['aside',   'Block', 'Flow', 'Common'],
+                ['header',  'Block', 'Flow', 'Common'],
+                ['footer',  'Block', 'Flow', 'Common'],
+				
+				// Content model actually excludes several tags, not modelled here
+                ['address', 'Block', 'Flow', 'Common'],
+                ['hgroup', 'Block', 'Required: h1 | h2 | h3 | h4 | h5 | h6', 'Common'],
+				
+				// http://developers.whatwg.org/grouping-content.html
+                ['figure', 'Block', 'Optional: (figcaption, Flow) | (Flow, figcaption) | Flow', 'Common'],
+                ['figcaption', 'Inline', 'Flow', 'Common'],
+				
+				// http://developers.whatwg.org/the-video-element.html#the-video-element
+                ['video', 'Block', 'Optional: (source, Flow) | (Flow, source) | Flow', 'Common', [
+                    'src' => 'URI',
+					'type' => 'Text',
+					'width' => 'Length',
+					'height' => 'Length',
+					'poster' => 'URI',
+					'preload' => 'Enum#auto,metadata,none',
+					'controls' => 'Bool',
+                ]],
+                ['source', 'Block', 'Flow', 'Common', [
+					'src' => 'URI',
+					'type' => 'Text',
+                ]],
+
+				// http://developers.whatwg.org/text-level-semantics.html
+                ['s',    'Inline', 'Inline', 'Common'],
+                ['var',  'Inline', 'Inline', 'Common'],
+                ['sub',  'Inline', 'Inline', 'Common'],
+                ['sup',  'Inline', 'Inline', 'Common'],
+                ['mark', 'Inline', 'Inline', 'Common'],
+                ['wbr',  'Inline', 'Empty', 'Core'],
+				
+				// http://developers.whatwg.org/edits.html
+                ['ins', 'Block', 'Flow', 'Common', ['cite' => 'URI', 'datetime' => 'CDATA']],
+                ['del', 'Block', 'Flow', 'Common', ['cite' => 'URI', 'datetime' => 'CDATA']],
+            ],
+            'attributes' => [
+                ['iframe', 'allowfullscreen', 'Bool'],
+                ['table', 'height', 'Text'],
+                ['td', 'border', 'Text'],
+                ['th', 'border', 'Text'],
+                ['tr', 'width', 'Text'],
+                ['tr', 'height', 'Text'],
+                ['tr', 'border', 'Text'],
+            ],
+        ],
+        'custom_attributes' => [
+            ['a', 'target', 'Enum#_blank,_self,_target,_top'],
+        ],
+        'custom_elements' => [
+            ['u', 'Inline', 'Inline', 'Common'],
+        ],
+    ],
+
+];

--- a/tests/Feature/HtmlSanitizerTest.php
+++ b/tests/Feature/HtmlSanitizerTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Support\HtmlSanitizer;
+use Tests\TestCase;
+
+class HtmlSanitizerTest extends TestCase
+{
+    public function test_it_strips_dangerous_html_and_keeps_allowed_tags(): void
+    {
+        $dirty = '<p>Bonjour <strong>club</strong></p>'
+            . '<script>alert(1)</script>'
+            . '<img src=x onerror="alert(2)">'
+            . '<a href="javascript:alert(3)">piege</a>'
+            . '<a href="https://bcj37.fr">site</a>'
+            . '<p style="color:red">rouge</p>'
+            . '<h2>Sous-titre</h2>';
+
+        $clean = HtmlSanitizer::post($dirty);
+
+        // Dangereux retire
+        $this->assertStringNotContainsString('<script', $clean);
+        $this->assertStringNotContainsStringIgnoringCase('onerror', $clean);
+        $this->assertStringNotContainsStringIgnoringCase('javascript:', $clean);
+        $this->assertStringNotContainsString('style=', $clean);
+        $this->assertStringNotContainsString('<img', $clean);
+
+        // Legitime conserve
+        $this->assertStringContainsString('<strong>club</strong>', $clean);
+        $this->assertStringContainsString('<h2>Sous-titre</h2>', $clean);
+        $this->assertStringContainsString('bcj37.fr', $clean);
+    }
+
+    public function test_it_preserves_plain_and_empty_values(): void
+    {
+        $this->assertNull(HtmlSanitizer::post(null));
+        $this->assertSame('', HtmlSanitizer::post(''));
+        $this->assertStringContainsString('Texte simple', (string) HtmlSanitizer::post('Texte simple'));
+    }
+}


### PR DESCRIPTION
## LOT 4 — Éditeur d'articles : sécurité du HTML

Le frontend React rend le contenu des articles en **HTML brut** (`dangerouslySetInnerHTML` sur `content`, `excerpt`, message d'accueil, article mis en avant). Ce contenu est désormais **nettoyé côté serveur par liste blanche** avant d'être exposé par l'API — la sécurité était le point obligatoire de ce lot.

### Choix de l'éditeur
L'éditeur en place est **Quill** (via l'extension de formulaire `ck5`). Plutôt que d'en changer (migration de contenu risquée), il est **restreint** aux formats sûrs et le contenu est **assaini côté serveur**. Choix motivé : Quill est déjà intégré, maintenu et léger ; le vrai manque était la sécurité, pas l'éditeur.

### Sécurité (HTMLPurifier)
- Dépendance **`mews/purifier`** (wrapper Laravel de HTMLPurifier, référence du domaine — écrire un nettoyage maison serait dangereux).
- Profil **`post`** (`config/purifier.php`) : liste blanche `p, br, strong/b, em/i, u, h1-h4, ul, ol, li, a[href|title], blockquote, pre, code`. **Interdit** : style inline, couleurs/polices, `<script>`, `<img>`, iframes. Schémas d'URL limités à `http/https/mailto` (bloque `javascript:`).
- `App\Support\HtmlSanitizer` : nettoyage centralisé.
- Appliqué **à la sortie** (`PostResource`, `IndexResource`) → couvre **tous les articles existants sans modifier la base** (donc réversible), **et à la sauvegarde** admin (stockage propre).

### Éditeur limité
Barre d'outils Quill réduite aux formats autorisés : titres **H2-H4**, gras, italique, souligné, citation, lien, listes, effacer la mise en forme. **Retirés** : police, taille, couleur, fond, indentation arbitraires.

### Compatibilité
- Anciens articles **préservés** — vérifié : **0 perte de texte** sur un article réel après nettoyage.
- **Aucune migration** ni transformation destructive : le nettoyage à la sortie n'altère pas la base (retour arrière trivial).

### Tests exécutés
- `HtmlSanitizerTest` : dangereux retiré (script / onerror / `javascript:` / style / img), légitime conservé (lien https, `<strong>`, `<h2>`). **2 passed**.
- API `/posts/slug/…` : contenu renvoyé sans `<script>` ni `style=`.
- Nettoyage d'un article réel : 0 perte de texte.
- `php artisan test` : **175 passed** (avant ajout du test dédié), aucune régression.

### Tests manuels (recette)
Créer/éditer un article, coller depuis Word (styles supprimés), insérer un lien, tenter une injection `<script>` → neutralisée ; vérifier le rendu public inchangé.

### Déploiement
`composer install` (nouvelle dépendance `mews/purifier`). Aucune migration.

### Reporté (améliorations associées)
Statut brouillon, publication programmée, date de publication, auteur de dernière modification, avertissement avant de quitter une page non enregistrée : nécessitent un changement de schéma + adaptations front/API. À traiter dans un lot dédié (le LOT 3 les signale déjà « non suivis »).
