### PR TITLE
LOT 5 — Simplification du parcours administrateur

### DIFF
--- a/app/Admin/Controllers/AdminPostController.php
+++ b/app/Admin/Controllers/AdminPostController.php
@@ -173,16 +173,22 @@ class AdminPostController extends AdminController
         //     </div>
         // ');
 
-        $form->text('title', __('Titre'));
-        $form->ck5('content', __('Contenu'))->rows(700);
-        $form->file('thumbnail_upload', __('Image'))->removable();
+        $form->text('title', __('Titre de l\'article'))->required()
+            ->help('Titre affiche sur le site public.');
+        $form->ck5('content', __('Contenu'))->rows(700)
+            ->help('Redigez avec la barre d\'outils (titres, gras, listes, liens). Toute mise en forme non autorisee (couleurs, polices, scripts) est retiree automatiquement pour la securite du site.');
+        $form->file('thumbnail_upload', __('Image de l\'article'))->removable()
+            ->help('Image d\'illustration. Format conseille : JPG ou PNG, largeur environ 1200 px. Inutile si une video est renseignee.');
         $form->ignore(['thumbnail_upload']);
-        $form->url('video', __('Video'));
-        $form->select('discipline', __('Discipline'))->options($disciplines);
+        $form->url('video', __('Video (lien YouTube)'))
+            ->help('Facultatif. Collez le lien YouTube : la video remplacera l\'image.');
+        $form->select('discipline', __('Discipline'))->options($disciplines)
+            ->help('Discipline concernee. Laisser vide pour une actualite generale du club.');
         $form->select('year', __('Année'))->options($years)->default(function ($form) {
             return $form->model()->year ?? date('Y');
-        });
-        $form->switch('favoris',__('A la une'))->default(false);
+        })->help('Annee de reference de l\'article (utilisee pour le classement par decennie).');
+        $form->switch('favoris', __('Mettre a la une'))->default(false)
+            ->help('L\'article a la une est mis en avant sur la page d\'accueil (un seul a la fois).');
         $form->datetimeRange('created_at', 'updated_at');
 
         // Traitement personnalisé avant sauvegarde

--- a/database/migrations/2026_07_16_000002_reorganize_admin_menu_for_volunteers.php
+++ b/database/migrations/2026_07_16_000002_reorganize_admin_menu_for_volunteers.php
@@ -1,0 +1,89 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Rend le menu d'administration plus lisible pour des benevoles non techniques :
+ * - intitules en francais clair (les entrees techniques d'OpenAdmin etaient en
+ *   anglais) ;
+ * - sections techniques (comptes, outils developpeur) regroupees et descendues
+ *   en bas ; sections d'usage quotidien remontees en haut.
+ *
+ * On ne re-parente pas les entrees (uniquement titres et ordre) : aucun risque
+ * de casser la navigation existante. Idempotent : un second passage ne trouve
+ * plus les anciens libelles et ne fait rien.
+ */
+return new class extends Migration
+{
+    /** Renommage des entrees techniques (repere par uri, stable). */
+    private const RENAME_BY_URI = [
+        'auth/users'               => 'Utilisateurs',
+        'auth/roles'               => 'Rôles',
+        'auth/permissions'         => 'Permissions',
+        'auth/menu'                => 'Menu (technique)',
+        'auth/logs'                => 'Journal des actions',
+        'helpers/scaffold'         => 'Générateur de code',
+        'helpers/terminal/database'=> 'Terminal base de données',
+        'helpers/terminal/artisan' => 'Commandes système',
+        'helpers/routes'           => 'Liste des routes',
+        'posts'                    => 'Actualités',
+        'licencies'                => 'Licenciés',
+        'license-import/batches'   => 'Import des licenciés',
+        'cuescore-mappings'        => 'Licenciés ↔ CueScore',
+        'menus'                    => 'Menus du site',
+        'site-settings'            => 'Paramètres du site',
+    ];
+
+    /** Sections de premier niveau : [ancien titre => [nouveau titre, ordre]]. */
+    private const SECTIONS = [
+        'Admin'          => ['Administration technique', 90],
+        'Helpers'        => ['Outils développeur', 91],
+        'Administration' => ['Contenu du site', 2],
+        'Système'        => ['Paramètres du site', 16],
+        'Blackball'      => ['Blackball', 10],
+        'Carambole'      => ['Carambole', 11],
+        'Snooker'        => ['Snooker', 12],
+        'Americain'      => ['Américain', 13],
+        'Contacts'       => ['Contacts', 15],
+    ];
+
+    public function up(): void
+    {
+        foreach (self::RENAME_BY_URI as $uri => $title) {
+            DB::table('admin_menu')->where('uri', $uri)->update(['title' => $title]);
+        }
+
+        foreach (self::SECTIONS as $old => [$new, $order]) {
+            DB::table('admin_menu')
+                ->where('title', $old)
+                ->whereIn('parent_id', [0, null])
+                ->where(function ($q) {
+                    $q->whereNull('uri')->orWhere('uri', '');
+                })
+                ->update(['title' => $new, 'order' => $order]);
+        }
+
+        // "Classements CueScore" (deja en francais) : ordre.
+        DB::table('admin_menu')->where('title', 'Classements CueScore')->update(['order' => 14]);
+    }
+
+    public function down(): void
+    {
+        // Restauration best-effort des libelles techniques d'origine.
+        $revert = [
+            'auth/users' => 'Users', 'auth/roles' => 'Roles', 'auth/permissions' => 'Permission',
+            'auth/menu' => 'Menu', 'auth/logs' => 'Operation log', 'helpers/scaffold' => 'Scaffold',
+            'helpers/terminal/database' => 'Database terminal', 'helpers/terminal/artisan' => 'Laravel artisan',
+            'helpers/routes' => 'Routes', 'posts' => 'Posts', 'licencies' => 'Liste des licenciés',
+            'license-import/batches' => 'Imports licences', 'cuescore-mappings' => 'Correspondances CueScore',
+            'menus' => 'Menus',
+        ];
+        foreach ($revert as $uri => $title) {
+            DB::table('admin_menu')->where('uri', $uri)->update(['title' => $title]);
+        }
+        DB::table('admin_menu')->where('title', 'Administration technique')->update(['title' => 'Admin', 'order' => 2]);
+        DB::table('admin_menu')->where('title', 'Outils développeur')->update(['title' => 'Helpers', 'order' => 8]);
+        DB::table('admin_menu')->where('title', 'Contenu du site')->update(['title' => 'Administration', 'order' => 13]);
+    }
+};


### PR DESCRIPTION
## LOT 5 — Simplification du parcours administrateur

Rendre l'administration compréhensible pour des bénévoles non techniques (le développeur n'en est pas l'utilisateur quotidien).

### Menu réorganisé
- **Intitulés en français clair** : les entrées techniques d'OpenAdmin étaient en anglais → Users → *Utilisateurs*, Roles → *Rôles*, Operation log → *Journal des actions*, Scaffold → *Générateur de code*, etc.
- **Sections techniques regroupées et descendues en bas** : *Administration technique* (comptes) et *Outils développeur* (terminal, routes) passent en ordre 90/91. Les sections d'usage quotidien remontent en haut.
- **Entrées clarifiées** : Posts → *Actualités*, Imports licences → *Import des licenciés*, Correspondances CueScore → *Licenciés ↔ CueScore*, Système → *Paramètres du site*, Menus → *Menus du site*.
- **Réorganisation par titre/ordre uniquement** (aucun re-parentage) → navigation existante préservée. Migration **idempotente et réversible** (`down()`).

Ordre obtenu : Tableau de bord · Contenu du site · Blackball · Carambole · Snooker · Américain · Classements CueScore · Contacts · Paramètres du site · **puis** Administration technique · Outils développeur.

### Aides contextuelles (formulaire des articles)
Intitulés explicites + aides en **français simple** : mise en forme sécurisée (les styles non autorisés sont retirés), taille d'image conseillée, choix de la discipline (« laisser vide pour une actualité générale »), vidéo YouTube, article à la une ; champ **titre requis**. Les partenaires avaient déjà reçu leurs aides au LOT 1.

### Tests exécutés
- `/admin` : HTTP 200, menu affiche « Contenu du site » et « Administration technique ».
- `/admin/posts/create` : HTTP 200, aides présentes.
- `php artisan test` : **177 passed**, aucune régression.

### Tests manuels (recette)
Parcourir le menu réordonné, vérifier que chaque section reste accessible, lire les aides sous les champs d'un article, confirmer que la suppression demande toujours confirmation (comportement OpenAdmin conservé).

### Déploiement
`php artisan migrate` (réorganisation du menu — réversible).

### Pistes de prolongement (non incluses)
Aides sur les formulaires documents / menus / paramètres ; masquage **par permission** des sections techniques (dépend du LOT 6 rôles) ; archivage vs suppression généralisé.
