### PR TITLE
LOT 6 — Rôles, permissions (côté serveur) et journal d'activité

### DIFF
--- a/database/migrations/2026_07_16_000004_seed_club_roles_and_permissions.php
+++ b/database/migrations/2026_07_16_000004_seed_club_roles_and_permissions.php
@@ -1,0 +1,112 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Rôles et permissions metier, batis sur le systeme RBAC natif d'OpenAdmin
+ * (aucun second systeme). L'enforcement est cote serveur : chaque permission
+ * porte un `http_path` verifie par le middleware Permission d'OpenAdmin — masquer
+ * un bouton ne suffirait pas.
+ *
+ * Le role `administrator` (compte principal) n'est pas touche : il conserve
+ * l'acces total (bypass isAdministrator d'OpenAdmin). Les nouveaux roles sont
+ * simplement disponibles pour etre attribues a des benevoles.
+ *
+ * Migration idempotente (reperage par slug).
+ */
+return new class extends Migration
+{
+    /** Permissions metier : [nom, slug, chemins http (enforcement serveur)]. */
+    private const PERMISSIONS = [
+        ['Actualités',           'content.articles',    "/posts*"],
+        ['Partenaires',          'content.partenaires', "/partenaires*"],
+        ['Documents',            'content.documents',   "/documents*"],
+        ['Classements CueScore', 'sport.classements',   "/cuescore-classements*\n/cuescore-mappings*"],
+        ['Licenciés',            'club.licencies',      "/licencies*\n/license-import*"],
+        ['Paramètres du site',   'club.parametres',     "/site-settings*\n/menus*\n/indices*\n/contacts*"],
+    ];
+
+    /** Roles : [nom, slug, permissions metier]. Les permissions de base
+     *  (tableau de bord, profil) sont ajoutees a chaque role. */
+    private const ROLES = [
+        ['Rédacteur',               'redacteur',        ['content.articles']],
+        ['Responsable partenaires', 'resp_partenaires', ['content.partenaires']],
+        ['Responsable documents',   'resp_documents',   ['content.documents']],
+        ['Administrateur du site',  'admin_site',       ['content.articles', 'content.partenaires', 'content.documents', 'sport.classements', 'club.licencies', 'club.parametres']],
+    ];
+
+    /** Permissions OpenAdmin par defaut requises par tout compte connecte. */
+    private const BASE_PERMISSIONS = ['dashboard', 'auth.setting', 'auth.login'];
+
+    /** Menus (par uri) rendus visibles pour chaque role. '/' = tableau de bord. */
+    private const ROLE_MENUS = [
+        'redacteur'        => ['/', 'posts'],
+        'resp_partenaires' => ['/', 'partenaires'],
+        'resp_documents'   => ['/', 'documents'],
+        'admin_site'       => ['/', 'posts', 'partenaires', 'documents', 'cuescore-classements', 'licencies', 'site-settings'],
+    ];
+
+    public function up(): void
+    {
+        $now = now();
+
+        // 1) Permissions metier.
+        $permId = [];
+        foreach (self::PERMISSIONS as [$name, $slug, $path]) {
+            $existing = DB::table('admin_permissions')->where('slug', $slug)->value('id');
+            $permId[$slug] = $existing ?: DB::table('admin_permissions')->insertGetId([
+                'name' => $name, 'slug' => $slug, 'http_method' => '', 'http_path' => $path,
+                'created_at' => $now, 'updated_at' => $now,
+            ]);
+        }
+        foreach (self::BASE_PERMISSIONS as $slug) {
+            $permId[$slug] = DB::table('admin_permissions')->where('slug', $slug)->value('id');
+        }
+
+        // 2) Roles + associations permissions.
+        foreach (self::ROLES as [$name, $slug, $perms]) {
+            $roleId = DB::table('admin_roles')->where('slug', $slug)->value('id')
+                ?: DB::table('admin_roles')->insertGetId([
+                    'name' => $name, 'slug' => $slug, 'created_at' => $now, 'updated_at' => $now,
+                ]);
+
+            foreach (array_merge(self::BASE_PERMISSIONS, $perms) as $pslug) {
+                if (empty($permId[$pslug])) {
+                    continue;
+                }
+                $has = DB::table('admin_role_permissions')
+                    ->where('role_id', $roleId)->where('permission_id', $permId[$pslug])->exists();
+                if (! $has) {
+                    DB::table('admin_role_permissions')->insert([
+                        'role_id' => $roleId, 'permission_id' => $permId[$pslug],
+                        'created_at' => $now, 'updated_at' => $now,
+                    ]);
+                }
+            }
+
+            // 3) Menus visibles pour ce role.
+            foreach (self::ROLE_MENUS[$slug] ?? [] as $uri) {
+                $menuId = DB::table('admin_menu')->where('uri', $uri)->value('id');
+                if ($menuId && ! DB::table('admin_role_menu')->where('role_id', $roleId)->where('menu_id', $menuId)->exists()) {
+                    DB::table('admin_role_menu')->insert([
+                        'role_id' => $roleId, 'menu_id' => $menuId,
+                        'created_at' => $now, 'updated_at' => $now,
+                    ]);
+                }
+            }
+        }
+    }
+
+    public function down(): void
+    {
+        $roleSlugs = array_column(self::ROLES, 1);
+        $roleIds = DB::table('admin_roles')->whereIn('slug', $roleSlugs)->pluck('id');
+
+        DB::table('admin_role_permissions')->whereIn('role_id', $roleIds)->delete();
+        DB::table('admin_role_menu')->whereIn('role_id', $roleIds)->delete();
+        DB::table('admin_role_users')->whereIn('role_id', $roleIds)->delete();
+        DB::table('admin_roles')->whereIn('slug', $roleSlugs)->delete();
+        DB::table('admin_permissions')->whereIn('slug', array_column(self::PERMISSIONS, 1))->delete();
+    }
+};


### PR DESCRIPTION
## LOT 6 — Rôles, permissions et journal d'activité

S'appuie **exclusivement sur le système RBAC natif d'OpenAdmin** (aucun second système) et sur son journal d'activité **déjà actif**.

### Constat (reprise)
- OpenAdmin fournissait déjà rôles / permissions / journal, mais **sans permissions métier** (seulement les permissions techniques par défaut).
- Le **journal d'activité est déjà activé** (`operation_log.enable = true`, table `admin_operation_log`, menu « Journal des actions ») → la traçabilité est en place.

### Permissions métier (enforcement **côté serveur**)
Chaque permission porte un `http_path` vérifié par le middleware Permission d'OpenAdmin — donc la sécurité **ne dépend pas du masquage de boutons** :
`Actualités` (`/posts*`), `Partenaires`, `Documents`, `Classements CueScore`, `Licenciés`, `Paramètres du site`.

### Rôles fonctionnels
- **Rédacteur** → Actualités
- **Responsable partenaires** → Partenaires
- **Responsable documents** → Documents
- **Administrateur du site** → toutes les permissions métier

Chaque rôle reçoit aussi l'accès au tableau de bord + profil, et la visibilité des menus correspondants. Le rôle **`administrator` n'est pas modifié** : accès total conservé (bypass `isAdministrator`) → **aucun risque de verrouillage** du compte principal.

### Attribution
Les rôles se posent depuis *Administration technique → Utilisateurs* (édition d'un compte).

### Tests exécutés (déterministes, sans rendu)
- Rôle Rédacteur = `dashboard, auth.setting, auth.login, content.articles` (exactement).
- `content.articles` **matche `/posts`**, **pas `/partenaires`** → Rédacteur **refusé côté serveur** sur les partenaires.
- `administrator.isAdministrator()` = oui (accès total préservé).
- `operation_log.enable` = oui (journal actif).
- `php artisan test` : **177 passed**, aucune régression.

### Tests manuels (recette)
Créer un compte avec le rôle Rédacteur, se connecter, vérifier l'accès aux Actualités et le **refus** sur Partenaires/Paramètres ; consulter le « Journal des actions » après une création/modification.

### Sécurité / données personnelles
Le journal OpenAdmin enregistre utilisateur, date, action, chemin ; il **n'enregistre pas** de mots de passe/jetons.

### Déploiement
`php artisan migrate` (seed rôles/permissions — idempotent et réversible).
