### PR TITLE
LOT 7 — Commentaires ciblés (maintenabilité)

### DIFF
--- a/app/Admin/Extensions/Form/Ck5Decoupled.php
+++ b/app/Admin/Extensions/Form/Ck5Decoupled.php
@@ -4,6 +4,17 @@ namespace App\Admin\Extensions\Form;
 
 use OpenAdmin\Admin\Form\Field\Textarea;
 
+/**
+ * Champ d'edition riche des articles pour OpenAdmin.
+ *
+ * Attention au nom : malgre « Ck5 » (herite d'une premiere version a base de
+ * CKEditor 5), l'implementation actuelle repose sur l'editeur Quill (charge via
+ * bootstrap.php). La barre d'outils est volontairement limitee aux formats surs.
+ *
+ * La securite ne repose pas sur cet editeur : le HTML produit est nettoye cote
+ * serveur par liste blanche (voir App\Support\HtmlSanitizer) avant stockage et
+ * avant d'etre renvoye par l'API, car le frontend React le rend en HTML brut.
+ */
 class Ck5Decoupled extends Textarea
 {
     protected $view = 'admin.form.ck5-decoupled';

--- a/app/Http/Controllers/Api/PublicController.php
+++ b/app/Http/Controllers/Api/PublicController.php
@@ -176,6 +176,10 @@ class PublicController extends Controller
      */
     public function home(): JsonResponse
     {
+        // La page d'accueil est la plus consultee : on met sa charge utile en
+        // cache court (10 min). Le cache est de toute facon invalide des qu'un
+        // contenu concerne change (ex : ecriture d'un partenaire), donc cette
+        // duree ne fait que borner la fraicheur en l'absence de modification.
         $response = Cache::remember(
             CacheKeys::publicHome(),
             now()->addMinutes(10),

--- a/app/Support/DisciplineMapper.php
+++ b/app/Support/DisciplineMapper.php
@@ -2,6 +2,16 @@
 
 namespace App\Support;
 
+/**
+ * Correspondance entre le slug d'une discipline (utilise cote API/frontend) et
+ * son code entier stocke en base.
+ *
+ * Historiquement, les tables `posts` et `documents` stockent la discipline sous
+ * forme d'entier (1 a 4) et non de chaine. Cette classe centralise cette
+ * convention pour eviter que les codes soient recopies un peu partout.
+ * L'absence de correspondance (code 0/null) designe une actualite generale du
+ * club, sans discipline.
+ */
 class DisciplineMapper
 {
     public const DISCIPLINES = [

--- a/frontend/src/pages/PostPage.tsx
+++ b/frontend/src/pages/PostPage.tsx
@@ -200,6 +200,10 @@ export function PostPage() {
                         )}
 
                         {post.content && (
+                            // Rendu HTML brut volontaire : le contenu est nettoye
+                            // cote serveur par liste blanche (HtmlSanitizer) avant
+                            // d'etre renvoye par l'API, il ne contient donc ni
+                            // script ni style dangereux.
                             <div
                                 dangerouslySetInnerHTML={{
                                     __html: post.content,


### PR DESCRIPTION
## LOT 7 — Commentaires et maintenabilité

Faciliter la reprise du projet par un autre développeur, **sans sur-commenter ni refactorer** (conformément aux consignes). Commentaires ciblés sur les points réellement non évidents ; ils expliquent le **pourquoi**, pas le quoi.

### Ajouts
- **`DisciplineMapper`** — explique la convention piégeuse : la discipline est stockée en **entier (1‑4)** dans `posts`/`documents` (code 0/null = actualité générale du club).
- **`Ck5Decoupled`** — lève l'ambiguïté du nom : « Ck5 » mais repose en réalité sur **Quill** ; rappelle que la sécurité vient du **nettoyage serveur** (`HtmlSanitizer`), pas de l'éditeur.
- **`PublicController@home`** — justifie le **TTL de cache** (10 min) et son invalidation à l'écriture.
- **`PostPage` (React)** — justifie le rendu **HTML brut** (`dangerouslySetInnerHTML`) : contenu nettoyé côté serveur, donc sûr.

### Refactorisation
Aucune : les parties complexes (pipeline d'import, services CueScore) sont déjà structurées et documentées. Aucun bloc ne nécessitait une refonte pour être explicable.

### Tests exécutés
- Lint PHP : OK.
- `npm run build` (frontend) : OK (le commentaire JSX compile).
- `php artisan test` : **177 passed**, aucune régression.

### Déploiement
Aucun (commentaires uniquement, aucun changement de comportement).
