### PR TITLE
LOT 9 — Bloc d'information administrable (page d'accueil)

### DIFF
--- a/app/Admin/Controllers/InfoBlockController.php
+++ b/app/Admin/Controllers/InfoBlockController.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Admin\Controllers;
+
+use App\Models\InfoBlock;
+use OpenAdmin\Admin\Controllers\AdminController;
+use OpenAdmin\Admin\Form;
+use OpenAdmin\Admin\Grid;
+use OpenAdmin\Admin\Show;
+
+/**
+ * Blocs d'information importants affiches sur la page d'accueil (fermeture,
+ * horaires, inscriptions, tournoi, info urgente...).
+ */
+class InfoBlockController extends AdminController
+{
+    protected $title = 'Informations page d\'accueil';
+
+    private const NIVEAUX = [
+        'info'      => 'Information',
+        'important' => 'Important',
+        'urgent'    => 'Urgent',
+    ];
+
+    private const NIVEAU_COLORS = [
+        'info'      => 'bg-info',
+        'important' => 'bg-warning',
+        'urgent'    => 'bg-danger',
+    ];
+
+    protected function grid()
+    {
+        $grid = new Grid(new InfoBlock());
+
+        $grid->model()->orderBy('ordre')->orderByDesc('id');
+
+        $grid->column('ordre', __('Ordre'))->sortable();
+        $grid->column('titre', __('Titre'));
+        $grid->column('niveau', __('Niveau'))->display(function ($niveau) {
+            $color = self::NIVEAU_COLORS[$niveau] ?? 'bg-secondary';
+            $label = self::NIVEAUX[$niveau] ?? $niveau;
+            return "<span class='badge {$color}'>{$label}</span>";
+        });
+        $grid->column('actif', __('Actif'))->display(function ($v) {
+            return $v
+                ? '<span class="badge bg-success">actif</span>'
+                : '<span class="badge bg-secondary">inactif</span>';
+        });
+        $grid->column('date_fin', __('Fin'));
+
+        $grid->filter(function ($filter) {
+            $filter->disableIdFilter();
+            $filter->like('titre', __('Titre'));
+            $filter->equal('niveau', __('Niveau'))->select(self::NIVEAUX);
+            $filter->equal('actif', __('Actif'))->select([0 => 'Non', 1 => 'Oui']);
+        });
+
+        return $grid;
+    }
+
+    protected function detail($id)
+    {
+        $show = new Show(InfoBlock::findOrFail($id));
+
+        $show->field('titre', __('Titre'));
+        $show->field('resume', __('Message'));
+        $show->field('niveau', __('Niveau'))->as(fn ($n) => self::NIVEAUX[$n] ?? $n);
+        $show->field('lien', __('Lien'));
+        $show->field('date_debut', __('Debut'));
+        $show->field('date_fin', __('Fin'));
+        $show->field('actif', __('Actif'))->as(fn ($v) => $v ? 'Oui' : 'Non');
+        $show->field('ordre', __('Ordre'));
+
+        return $show;
+    }
+
+    protected function form()
+    {
+        $form = new Form(new InfoBlock());
+
+        $form->text('titre', __('Titre'))->required()
+            ->help('Titre court affiche en tete du bloc (ex : « Fermeture exceptionnelle »).');
+        $form->textarea('resume', __('Message'))
+            ->help('Texte du message affiche aux visiteurs.');
+        $form->select('niveau', __('Niveau d\'importance'))->options(self::NIVEAUX)->default('info')
+            ->help('Information (bleu), Important (orange) ou Urgent (rouge) : change la couleur du bloc.');
+        $form->url('lien', __('Lien (facultatif)'))
+            ->help('Si renseigne, un bouton « En savoir plus » renverra vers cette adresse.');
+        $form->date('date_debut', __('Date de debut (facultatif)'))
+            ->help('Avant cette date, le bloc n\'est pas affiche.');
+        $form->date('date_fin', __('Date de fin (facultatif)'))
+            ->help('Apres cette date, le bloc n\'est plus affiche (mais reste enregistre).');
+        $form->number('ordre', __('Ordre d\'affichage'))->default(0)
+            ->help('Si plusieurs blocs sont actifs, le plus petit nombre s\'affiche en premier.');
+        $form->switch('actif', __('Actif'))->default(true)
+            ->help('Desactiver masque le bloc du site sans le supprimer.');
+
+        return $form;
+    }
+}

--- a/app/Admin/routes.php
+++ b/app/Admin/routes.php
@@ -87,6 +87,7 @@ Route::group([
     $router->resource('site-settings', SiteSettingController::class);
     $router->resource('licencies', AdminLicenciesController::class);
     $router->resource('partenaires', AdminPartenairesController::class);
+    $router->resource('info-blocks', InfoBlockController::class);
 
     // Import de licences (pipeline Telemat / FFBI) - lecture seule + declenchement
     $router->get('license-import/run', [LicenseImportBatchAdminController::class, 'run'])->name('license-import.run');

--- a/app/Http/Controllers/Api/PublicController.php
+++ b/app/Http/Controllers/Api/PublicController.php
@@ -5,11 +5,13 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\MenuResource;
 use App\Http\Resources\PartnerResource;
+use App\Http\Resources\InfoBlockResource;
 use App\Http\Resources\PostResource;
 use App\Http\Resources\SiteSettingsResource;
 use App\Http\Resources\IndexResource;
 use App\Models\Menu;
 use App\Models\Partenaire;
+use App\Models\InfoBlock;
 use App\Models\Post;
 use App\Models\SiteSetting;
 use App\Models\Index;
@@ -193,6 +195,8 @@ class PublicController extends Controller
 
                 $partners = Partenaire::visible()->get();
 
+                $infoBlocks = InfoBlock::visible()->get();
+
                 $featuredPost = Post::query()
                     ->where('favoris', true)
                     ->orderByDesc('created_at')
@@ -211,6 +215,7 @@ class PublicController extends Controller
                         'site_settings' => $siteSettings ? new SiteSettingsResource($siteSettings) : null,
                         'menus' => MenuResource::collection($menus),
                         'partners' => PartnerResource::collection($partners),
+                        'info_blocks' => InfoBlockResource::collection($infoBlocks),
                         'featured_post' => $featuredPost ? new PostResource($featuredPost) : null,
                         'welcome_message' => $index ? new IndexResource($index) : null,
                         'site'=> [

--- a/app/Http/Resources/InfoBlockResource.php
+++ b/app/Http/Resources/InfoBlockResource.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class InfoBlockResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'titre' => $this->titre,
+            'resume' => $this->resume,
+            'niveau' => $this->niveau,
+            'lien' => $this->lien,
+            'date_debut' => optional($this->date_debut)->toDateString(),
+            'date_fin' => optional($this->date_fin)->toDateString(),
+        ];
+    }
+}

--- a/app/Models/InfoBlock.php
+++ b/app/Models/InfoBlock.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Models;
+
+use App\Support\ApiCacheInvalidator;
+use Illuminate\Database\Eloquent\Model;
+
+class InfoBlock extends Model
+{
+    protected $table = 'info_blocks';
+
+    protected $fillable = [
+        'titre',
+        'resume',
+        'niveau',
+        'lien',
+        'date_debut',
+        'date_fin',
+        'actif',
+        'ordre',
+    ];
+
+    protected $casts = [
+        'actif' => 'boolean',
+        'ordre' => 'integer',
+        'date_debut' => 'date',
+        'date_fin' => 'date',
+    ];
+
+    /**
+     * Blocs affichables publiquement : actifs et dans leur fenetre de dates
+     * (facultatives), les plus importants d'abord.
+     */
+    public function scopeVisible($query)
+    {
+        $today = now()->toDateString();
+
+        return $query
+            ->where('actif', true)
+            ->where(fn ($q) => $q->whereNull('date_debut')->orWhere('date_debut', '<=', $today))
+            ->where(fn ($q) => $q->whereNull('date_fin')->orWhere('date_fin', '>=', $today))
+            ->orderBy('ordre')
+            ->orderByDesc('id');
+    }
+
+    /**
+     * Le bloc est affiche sur la page d'accueil (mise en cache) : toute ecriture
+     * invalide ce cache pour un affichage immediat.
+     */
+    protected static function booted(): void
+    {
+        $forget = static fn () => app(ApiCacheInvalidator::class)->publicHome();
+
+        static::saved($forget);
+        static::deleted($forget);
+    }
+}

--- a/database/migrations/2026_07_16_000005_create_info_blocks_table.php
+++ b/database/migrations/2026_07_16_000005_create_info_blocks_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Bloc d'information important, administrable, affiche sur la page d'accueil :
+ * fermeture exceptionnelle, changement d'horaire, inscriptions, tournoi, info
+ * urgente. Un bloc peut etre desactive ou sortir de sa fenetre de dates sans
+ * etre supprime.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('info_blocks', function (Blueprint $table) {
+            $table->id();
+            $table->string('titre');
+            $table->text('resume')->nullable();
+            // Niveau d'importance : info | important | urgent (pilote la couleur).
+            $table->string('niveau')->default('info');
+            $table->string('lien')->nullable();
+            $table->date('date_debut')->nullable();
+            $table->date('date_fin')->nullable();
+            $table->boolean('actif')->default(true);
+            $table->unsignedInteger('ordre')->default(0);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('info_blocks');
+    }
+};

--- a/database/migrations/2026_07_16_000006_add_info_blocks_admin_menu.php
+++ b/database/migrations/2026_07_16_000006_add_info_blocks_admin_menu.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Entree de menu OpenAdmin « Informations accueil », rangee dans la meme section
+ * que les autres contenus du site (parent de l'entree « posts »).
+ */
+return new class extends Migration
+{
+    private const URI = 'info-blocks';
+
+    public function up(): void
+    {
+        if (DB::table('admin_menu')->where('uri', self::URI)->exists()) {
+            return;
+        }
+
+        // Rattache a la meme section que les actualites, quel que soit son
+        // libelle actuel (Administration / Contenu du site selon les lots).
+        $parentId = (int) DB::table('admin_menu')->where('uri', 'posts')->value('parent_id');
+
+        $order = (int) DB::table('admin_menu')->where('parent_id', $parentId)->max('order');
+
+        DB::table('admin_menu')->insert([
+            'parent_id'  => $parentId,
+            'order'      => $order + 1,
+            'title'      => 'Informations accueil',
+            'icon'       => 'icon-bullhorn',
+            'uri'        => self::URI,
+            'permission' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    public function down(): void
+    {
+        DB::table('admin_menu')->where('uri', self::URI)->delete();
+    }
+};

--- a/frontend/src/components/info/InfoBanner.tsx
+++ b/frontend/src/components/info/InfoBanner.tsx
@@ -1,0 +1,58 @@
+import type { InfoBlock } from "../../types/api";
+import "../../styles/infoBanner.css";
+
+const LEVEL_CLASS: Record<string, string> = {
+    info: "info-banner--info",
+    important: "info-banner--important",
+    urgent: "info-banner--urgent",
+};
+
+type InfoBannerProps = {
+    blocks: InfoBlock[];
+};
+
+/**
+ * Blocs d'information importants (fermeture, tournoi, info urgente...) affiches
+ * en haut de la page d'accueil. Le niveau pilote la couleur ; les blocs urgents
+ * sont annonces aux lecteurs d'ecran (role="alert").
+ */
+export function InfoBanner({ blocks }: InfoBannerProps) {
+    if (!blocks?.length) {
+        return null;
+    }
+
+    return (
+        <section className="info-banners" aria-label="Informations importantes">
+            {blocks.map((block) => {
+                const isExternal = Boolean(block.lien && /^https?:\/\//i.test(block.lien));
+
+                return (
+                    <div
+                        key={block.id}
+                        className={`info-banner ${LEVEL_CLASS[block.niveau] ?? LEVEL_CLASS.info}`}
+                        role={block.niveau === "urgent" ? "alert" : "status"}
+                    >
+                        <div className="info-banner__body">
+                            <strong className="info-banner__title">{block.titre}</strong>
+                            {block.resume && (
+                                <span className="info-banner__text">{block.resume}</span>
+                            )}
+                        </div>
+
+                        {block.lien && (
+                            <a
+                                className="info-banner__link"
+                                href={block.lien}
+                                {...(isExternal
+                                    ? { target: "_blank", rel: "noopener noreferrer" }
+                                    : {})}
+                            >
+                                En savoir plus
+                            </a>
+                        )}
+                    </div>
+                );
+            })}
+        </section>
+    );
+}

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -3,6 +3,7 @@ import { getHome } from "../api/publicApi";
 import { Link } from "react-router-dom";
 import type { HomeData } from "../types/api";
 import { ClubMap } from "../components/map/ClubMap";
+import { InfoBanner } from "../components/info/InfoBanner";
 import { ArticleCard } from "../components/ui/Card";
 import { ArticleTitle } from "../components/ui/Title";
 import { PartnersCarousel } from "../components/partners/PartnersCarousel";
@@ -52,6 +53,7 @@ export function HomePage() {
                 />
             )}
         </div>
+        <InfoBanner blocks={home?.info_blocks ?? []} />
         <div className="home-layout">
             <section className="accueil" aria-labelledby="accueil-title">
                 <ArticleTitle>Accueil</ArticleTitle>

--- a/frontend/src/styles/infoBanner.css
+++ b/frontend/src/styles/infoBanner.css
@@ -1,0 +1,62 @@
+.info-banners {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    margin-bottom: 1.5rem;
+    /* Aligne les bannieres sur la largeur du contenu (cf. .home-layout). */
+    padding: 0 2rem;
+}
+
+.info-banner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    flex-wrap: wrap;
+    padding: 0.85rem 1.1rem;
+    border-radius: 10px;
+    border-left: 5px solid;
+}
+
+.info-banner__body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+}
+
+.info-banner__title {
+    font-weight: 700;
+}
+
+.info-banner__link {
+    flex: 0 0 auto;
+    font-weight: 600;
+    text-decoration: underline;
+    white-space: nowrap;
+    color: inherit;
+}
+
+.info-banner__link:focus-visible {
+    outline: 2px solid currentColor;
+    outline-offset: 3px;
+}
+
+/* Niveaux d'importance (contraste tenu, l'info n'est pas portee que par la couleur :
+   le titre reste explicite). */
+.info-banner--info {
+    background: #eff8ff;
+    border-color: #175cd3;
+    color: #1849a9;
+}
+
+.info-banner--important {
+    background: #fffaeb;
+    border-color: #f79009;
+    color: #b54708;
+}
+
+.info-banner--urgent {
+    background: #fef3f2;
+    border-color: #b42318;
+    color: #7a271a;
+}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -77,10 +77,21 @@ export type Post = {
     created_at?: string | null;
 };
 
+export type InfoBlock = {
+    id: number;
+    titre: string;
+    resume?: string | null;
+    niveau: "info" | "important" | "urgent" | string;
+    lien?: string | null;
+    date_debut?: string | null;
+    date_fin?: string | null;
+};
+
 export type HomeData = {
     site_settings: SiteSettings | null;
     menus: Menu[];
     partners: Partner[];
+    info_blocks: InfoBlock[];
     featured_post: Post | null;
     welcome_message: WelcomeMessage | null;
 };


### PR DESCRIPTION
## LOT 9 — Bloc d'information important (page d'accueil)

Le **LOT 9 est optionnel** (« uniquement si ça s'insère proprement »). Sur ses deux parties :
- **Bloc d'information** → feature propre et autonome, forte valeur → **implémentée**.
- **Bibliothèque de médias** → recoupe les uploads déjà en place, et une gestion centralisée avec détection d'inutilisés + suppression sécurisée représenterait un périmètre disproportionné → **reportée** (justifié).

### Fonctionnalité
Le club peut publier une information importante (fermeture exceptionnelle, horaires, inscriptions, tournoi, info urgente) sur la page d'accueil.

**Back**
- Table `info_blocks` (titre, résumé, niveau, lien, dates début/fin, actif, ordre). Un bloc terminé se **désactive** ou sort de sa fenêtre de dates — jamais supprimé automatiquement.
- Modèle `InfoBlock` : scope `visible()` + invalidation du cache d'accueil à l'écriture.
- API `/public/home` : nouvelle clé `info_blocks` (blocs visibles, du plus important au moins).
- CRUD admin `InfoBlockController` avec aides en français + menu « Informations accueil ».

**Front**
- Composant `InfoBanner` : bannières en haut de l'accueil, **couleur selon le niveau** (info/important/urgent), bloc urgent annoncé aux lecteurs d'écran (`role="alert"`), lien facultatif sécurisé (`rel="noopener noreferrer"`). L'information n'est **pas** portée par la seule couleur (titre explicite).

### Tests exécutés
- `php artisan migrate` : OK (table + menu).
- API : `/public/home` renvoie `info_blocks` (bloc de test affiché puis nettoyé).
- Admin : `/admin/info-blocks` et `/admin/info-blocks/create` → HTTP 200 ; menu « Informations accueil » présent.
- `npm run build` (frontend) : OK.
- `php artisan test` : **180 passed**, aucune régression.

### Tests manuels (recette)
Créer un bloc (chaque niveau), vérifier l'affichage/couleur en tête d'accueil, le lien « En savoir plus », la désactivation et les dates de début/fin.

### Déploiement
`php artisan migrate` (table + entrée de menu).
