### PR TITLE
LOT 11 — Tests & contrôle qualité

### DIFF
--- a/app/Admin/routes.php
+++ b/app/Admin/routes.php
@@ -1,49 +1,30 @@
 <?php
 
-use App\Admin\Controllers\AdminCalendrierSnooker;
 use App\Admin\Controllers\AdminDocumentController;
 use App\Admin\Controllers\AdminIndex;
 use App\Admin\Controllers\AdminLicenciesController;
 use App\Admin\Controllers\AdminPartenairesController;
 use App\Admin\Controllers\AdminPostController;
-use App\Admin\Controllers\LicenseImportBatchAdminController;
-use App\Admin\Controllers\CueScorePlayerMappingController;
-use App\Admin\Controllers\CueScoreRankingController;
 use App\Admin\Controllers\americain\AdminAmericainCalendrier;
-use App\Admin\Controllers\americain\AdminAmericainCalendrierDepartemental;
-use App\Admin\Controllers\americain\AdminAmericainCalendrierInternational;
-use App\Admin\Controllers\americain\AdminAmericainCalendrierNational;
-use App\Admin\Controllers\americain\AdminAmericainCalendrierRegional;
-use App\Admin\Controllers\blackball\AdminCalendrierDepartemental;
-use App\Admin\Controllers\blackball\AdminCalendrierInternational;
-use App\Admin\Controllers\blackball\AdminCalendrierNational;
-use App\Admin\Controllers\blackball\AdminCalendrierRegional;
+use App\Admin\Controllers\CalendarEventController;
 use App\Admin\Controllers\carambole\AdminCaramboleCalendrier;
-use App\Admin\Controllers\carambole\AdminCaramboleCalendrierDepartemental;
-use App\Admin\Controllers\carambole\AdminCaramboleCalendrierInternational;
-use App\Admin\Controllers\carambole\AdminCaramboleCalendrierNational;
-use App\Admin\Controllers\carambole\AdminCaramboleCalendrierRegional;
 use App\Admin\Controllers\carambole\AdminCaramboleClassement;
 use App\Admin\Controllers\ContactAdminController;
+use App\Admin\Controllers\CueScorePlayerMappingController;
+use App\Admin\Controllers\CueScoreRankingController;
+use App\Admin\Controllers\LicenseImportBatchAdminController;
 use App\Admin\Controllers\MenuController;
 use App\Admin\Controllers\SiteSettingController;
-use App\Admin\Controllers\SiteSettingDashboardController;
 use App\Admin\Controllers\snooker\AdminSnookerCalendrier;
-use App\Admin\Controllers\snooker\AdminSnookerCalendrierDepartemental;
-use App\Admin\Controllers\snooker\AdminSnookerCalendrierInternational;
-use App\Admin\Controllers\snooker\AdminSnookerCalendrierNational;
-use App\Admin\Controllers\snooker\AdminSnookerCalendrierRegional;
-use App\Admin\Controllers\CalendarEventController;
 use Illuminate\Routing\Router;
-use Illuminate\Support\Facades\Artisan;
 
 Admin::routes();
 
 Route::group([
-    'prefix'        => config('admin.route.prefix'),
-    'namespace'     => config('admin.route.namespace'),
-    'middleware'    => config('admin.route.middleware'),
-    'as'            => config('admin.route.prefix') . '.',
+    'prefix' => config('admin.route.prefix'),
+    'namespace' => config('admin.route.namespace'),
+    'middleware' => config('admin.route.middleware'),
+    'as' => config('admin.route.prefix').'.',
 ], function (Router $router) {
 
     $router->get('/', 'HomeController@index')->name('home');
@@ -62,25 +43,14 @@ Route::group([
     $router->get('/blackball/calendrier', 'AdminBlackballController@calendrier')->name('blackball.calendrier');
     $router->get('/club/licencies', 'AdminLicenciesController@licencies')->name('club.licencies');
 
-
     $router->resource('menus', MenuController::class);
     $router->resource('posts', AdminPostController::class);
 
-    // Route pour le blackball admin
-    $router->resource('calendrier_departementals', AdminCalendrierDepartemental::class);
-    $router->resource('calendrier_nationals', AdminCalendrierNational::class);
-    $router->resource('calendrier_regionals', AdminCalendrierRegional::class);
-    $router->resource('calendrier_internationals', AdminCalendrierInternational::class);
     $router->resource('documents', AdminDocumentController::class);
 
     // Route pour le carambole admin
     $router->resource('classement-caramboles', AdminCaramboleClassement::class);
     $router->resource('carambole-calendriers', AdminCaramboleCalendrier::class);
-    $router->resource('carambole-calendrier-internationals', AdminCaramboleCalendrierInternational::class)->parameters(['carambole-calendrier-internationals' => 'caramboleCalIntl']);
-    $router->resource('carambole-calendrier-nationals', AdminCaramboleCalendrierNational::class)->parameters(['carambole-calendrier-nationals' => 'caramboleCalNat']);
-    $router->resource('carambole-calendrier-regionals', AdminCaramboleCalendrierRegional::class)->parameters(['carambole-calendrier-regionals' => 'caramboleCalReg']);
-    $router->resource('carambole-calendrier-departementals', AdminCaramboleCalendrierDepartemental::class)->parameters(['carambole-calendrier-departementals' => 'caramboleCalDep']);
-
 
     $router->resource('indices', AdminIndex::class);
     $router->resource('contacts', ContactAdminController::class);
@@ -103,17 +73,9 @@ Route::group([
 
     // Route pour le snooker admin calendrier
     $router->resource('snooker-calendriers', AdminSnookerCalendrier::class);
-    $router->resource('snooker-calendrier-internationals', AdminSnookerCalendrierInternational::class)->parameters(['snooker-calendrier-internationals' => 'snookerCalIntl']);
-    $router->resource('snooker-calendrier-nationals', AdminSnookerCalendrierNational::class)->parameters(['snooker-calendrier-nationals' => 'snookerCalNat']);
-    $router->resource('snooker-calendrier-regionals', AdminSnookerCalendrierRegional::class)->parameters(['snooker-calendrier-regionals' => 'snookerCalReg']);
-    $router->resource('snooker-calendrier-departementals', AdminSnookerCalendrierDepartemental::class)->parameters(['snooker-calendrier-departementals' => 'snookerCalDep']);
 
     // Route pour l'américain admin calendrier
     $router->resource('americain-calendriers', AdminAmericainCalendrier::class);
-    $router->resource('americain-calendrier-internationals', AdminAmericainCalendrierInternational::class)->parameters(['americain-calendrier-internationals' => 'americainCalIntl']);
-    $router->resource('americain-calendrier-nationals', AdminAmericainCalendrierNational::class)->parameters(['americain-calendrier-nationals' => 'americainCalNat']);
-    $router->resource('americain-calendrier-regionals', AdminAmericainCalendrierRegional::class)->parameters(['americain-calendrier-regionals' => 'americainCalReg']);
-    $router->resource('americain-calendrier-departementals', AdminAmericainCalendrierDepartemental::class)->parameters(['americain-calendrier-departementals' => 'americainCalDep']);
 
     $calendarScopes = [
         'international',
@@ -139,22 +101,22 @@ Route::group([
                 "calendriers/{$discipline}/{$scope}/events/{event}/links",
                 [CalendarEventController::class, 'saveLinks']
             );
+            // Nom de route unique par discipline+portee : sans cela, les 16
+            // combinaisons partagent le nom « events.* » (dernier segment de
+            // l'URI) et la mise en cache des routes (route:cache) echoue.
             $router->resource(
                 "calendriers/{$discipline}/{$scope}/events",
                 CalendarEventController::class
-            );
+            )->names("calendriers.{$discipline}.{$scope}.events");
         }
     }
 
-    $router->get('calendrier_internationals', [AdminCalendrierInternational::class, 'index']);
-    $router->get('calendrier_nationals', [AdminCalendrierNational::class, 'index']);
-    $router->get('calendrier_regionals', [AdminCalendrierRegional::class, 'index']);
     $router->get('documents', [AdminDocumentController::class, 'index']);
     $router->get('carambole-calendriers', [AdminCaramboleCalendrier::class, 'index']);
 
     $router->post('/menu/{id}/toggle', function ($id) {
         $menu = \App\Models\Menu::findOrFail($id);
-        $menu->actif = !$menu->actif;
+        $menu->actif = ! $menu->actif;
         $menu->save();
 
         return response()->json(['success' => true, 'actif' => $menu->actif]);

--- a/docs/tests-manuels.md
+++ b/docs/tests-manuels.md
@@ -1,0 +1,118 @@
+# Checklist de tests manuels
+
+Ce document complète les tests automatisés (`php artisan test`, `npm run lint`,
+`npm run build`). Il liste les vérifications à faire **à la main** avant une mise
+en production, car elles portent sur le rendu, l'accessibilité et des parcours
+qui ne sont pas entièrement couverts par les tests automatisés.
+
+Convention : cocher `[x]` quand la vérification est faite et concluante ; noter la
+date et la version testée en bas de page.
+
+---
+
+## 1. Site public
+
+### 1.1 Rendu et responsive
+- [ ] Page d'accueil correcte sur **ordinateur**, **tablette**, **téléphone**.
+- [ ] Vérifié sur **Chrome** et **Firefox** (au moins).
+- [ ] Aucune barre de défilement **horizontale** parasite.
+- [ ] Bannière : présente → s'affiche ; absente → pas d'espace vide ni d'erreur.
+
+### 1.2 Partenaires
+- [ ] **0 partenaire** : le bloc affiche « Aucun partenaire » (pas d'erreur).
+- [ ] **1 à 3 partenaires** : rangée statique centrée (pas de défilement).
+- [ ] **4 partenaires ou plus** : carrousel qui défile en boucle sans saut.
+- [ ] Logo manquant : le **nom** du partenaire s'affiche à la place.
+- [ ] Partenaire **sans lien** : pas de lien cliquable, juste le logo/nom.
+- [ ] Partenaire **avec lien** : ouvre dans un nouvel onglet (`rel="noopener"`).
+- [ ] **Navigation clavier** : les liens partenaires sont atteignables au `Tab`,
+      focus visible ; les logos dupliqués du carrousel ne sont pas focusables.
+- [ ] **Mouvement réduit** (`prefers-reduced-motion`) : le carrousel ne défile
+      pas automatiquement (liste statique).
+
+### 1.3 Blocs d'information
+- [ ] Bloc **info / important / urgent** : couleur et libellé corrects.
+- [ ] Un bloc **urgent** est annoncé aux lecteurs d'écran (`role="alert"`).
+- [ ] Bloc **hors fenêtre de dates** ou **désactivé** : non affiché.
+- [ ] Lien externe → nouvel onglet ; lien interne → même onglet.
+
+### 1.4 Contenu
+- [ ] Article mis en avant : titre, image **ou** vidéo, contenu formaté.
+- [ ] Message d'accueil riche : mise en forme respectée, **pas de script injecté**.
+- [ ] Carte « Nous trouver » : la carte se charge.
+
+---
+
+## 2. Administration (OpenAdmin)
+
+### 2.1 Connexion et tableau de bord
+- [ ] Connexion administrateur.
+- [ ] Le tableau de bord n'affiche que des **chiffres réels** ; les indicateurs
+      non suivis (répartition licenciés, cotisations) sont signalés comme tels.
+- [ ] Le compteur « Documents » ouvre **tous** les documents (pas seulement une
+      discipline) ; le **filtre par catégorie** fonctionne ; la catégorie apparaît
+      en **label** sur chaque ligne.
+
+### 2.2 Articles
+- [ ] Créer un article : titre obligatoire, enregistrement OK.
+- [ ] Coller depuis **Word** : le contenu est nettoyé (pas de styles parasites).
+- [ ] Insérer un lien, puis une **tentative d'injection** (`<script>`) : neutralisée.
+- [ ] Éditer un ancien article : contenu préservé.
+- [ ] Miniature : upload, remplacement, affichage côté public.
+
+### 2.3 Partenaires
+- [ ] Ajouter un partenaire, définir un **ordre**, réordonner.
+- [ ] **Désactiver** un partenaire → disparaît du site public.
+- [ ] **Date de fin** dépassée → disparaît du site public.
+- [ ] Partenaire proche de l'expiration → remonté sur le tableau de bord.
+
+### 2.4 Rôles et permissions
+- [ ] Créer un compte avec le rôle **Rédacteur** : accès **articles uniquement**.
+- [ ] Ce compte **ne voit pas** et **ne peut pas ouvrir** (URL directe) les
+      licenciés, les paramètres, les partenaires.
+- [ ] Rôle **Responsable partenaires** : accès partenaires seulement.
+- [ ] Le compte **administrateur** conserve l'accès total.
+
+### 2.5 Calendriers et classements
+- [ ] Créer / éditer un événement de calendrier pour chaque discipline+portée.
+- [ ] Ajouter des liens à un événement.
+- [ ] Classements CueScore : créer une entrée par discipline/portée/catégorie,
+      la lier à une page discipline, vérifier l'affichage public.
+
+### 2.6 Import de licences (pipeline)
+- [ ] Déclencher un import : le lot apparaît dans la liste.
+- [ ] Consulter un lot : résumé, avertissements, statut.
+- [ ] Revue des correspondances CueScore → licencié.
+
+---
+
+## 3. API publique
+
+- [ ] `GET /api/v1/public/home` : sections attendues (site, menus, partenaires,
+      blocs info, article mis en avant).
+- [ ] `GET /api/v1/partenaires` : enveloppe standard `data / meta / links / error`.
+- [ ] `POST /api/v1/contact` sans données : **422** avec `errors` détaillés.
+- [ ] Réponses **vides** (aucune donnée) : structure correcte, pas d'erreur 500.
+- [ ] **Pagination** et **filtres** : cohérents avec la documentation.
+- [ ] Documentation générée accessible sur `/docs` ; OpenAPI/Postman à jour
+      (`php artisan scribe:generate`).
+
+---
+
+## 4. Vérifications techniques (commandes)
+
+À exécuter avant livraison — voir le rapport du lot pour les résultats datés.
+
+| Commande | Attendu |
+| --- | --- |
+| `php artisan test` | tous les tests au vert |
+| `npm run lint` (dossier `frontend`) | aucune erreur |
+| `npm run build` (dossier `frontend`) | build réussi |
+| `vendor/bin/pint --test` | style conforme |
+| `php artisan route:list` | se charge sans exception |
+| `php artisan route:cache` | mise en cache réussie |
+| `php artisan scribe:generate` | doc + OpenAPI + Postman générés |
+
+---
+
+_Dernière exécution manuelle : ____ / ____ / ______ — version / branche : _______________

--- a/frontend/src/components/partners/PartnersCarousel.tsx
+++ b/frontend/src/components/partners/PartnersCarousel.tsx
@@ -10,11 +10,17 @@ import "../../styles/partnersCarousel.css";
 const MIN_FOR_SCROLL = 4;
 
 function usePrefersReducedMotion(): boolean {
-    const [reduced, setReduced] = useState(false);
+    // Valeur initiale lue de facon paresseuse : l'effet ne fait que s'abonner
+    // aux changements, sans appeler setState de maniere synchrone a l'interieur
+    // (ce qui declencherait un rendu en cascade).
+    const [reduced, setReduced] = useState(
+        () =>
+            typeof window !== "undefined" &&
+            window.matchMedia("(prefers-reduced-motion: reduce)").matches,
+    );
 
     useEffect(() => {
         const query = window.matchMedia("(prefers-reduced-motion: reduce)");
-        setReduced(query.matches);
         const onChange = () => setReduced(query.matches);
         query.addEventListener("change", onChange);
         return () => query.removeEventListener("change", onChange);

--- a/tests/Feature/ClubDashboardServiceTest.php
+++ b/tests/Feature/ClubDashboardServiceTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Partenaire;
+use App\Services\ClubDashboardService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * Verifie que le tableau de bord n'agrege que des donnees reellement presentes
+ * en base (pas d'approximation) et que la structure attendue par la vue est la.
+ */
+class ClubDashboardServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_metrics_expose_all_expected_sections(): void
+    {
+        $metrics = app(ClubDashboardService::class)->metrics();
+
+        foreach (['articles', 'documents', 'partenaires', 'licencies', 'evenements', 'technique'] as $section) {
+            $this->assertArrayHasKey($section, $metrics);
+        }
+    }
+
+    public function test_it_counts_articles_and_groups_them_by_discipline(): void
+    {
+        // Insertion directe (query builder) volontaire : elle n'ecrit que sur des
+        // colonnes reellement presentes en base, sans dependre de la fabrique Post
+        // ni d'eventuels attributs par defaut du modele.
+        $this->makePost('Blackball 1', 1);
+        $this->makePost('Blackball 2', 1);
+        $this->makePost('Carambole 1', 2);
+
+        $articles = app(ClubDashboardService::class)->metrics()['articles'];
+
+        $this->assertSame(3, $articles['total']);
+        $this->assertSame(2, $articles['byDiscipline']['Blackball']);
+        $this->assertSame(1, $articles['byDiscipline']['Carambole']);
+    }
+
+    public function test_partner_metric_only_counts_visible_partners(): void
+    {
+        Partenaire::create(['titre' => 'Actif', 'actif' => true]);
+        Partenaire::create(['titre' => 'Inactif', 'actif' => false]);
+        Partenaire::create([
+            'titre' => 'Expire bientot',
+            'actif' => true,
+            'date_fin' => now()->addDays(10)->toDateString(),
+        ]);
+
+        $partenaires = app(ClubDashboardService::class)->metrics()['partenaires'];
+
+        $this->assertSame(2, $partenaires['active']);
+        $this->assertCount(1, $partenaires['expiringSoon']);
+    }
+
+    private function makePost(string $title, int $discipline): void
+    {
+        DB::table('posts')->insert([
+            'title' => $title,
+            'slug' => str($title)->slug()->value(),
+            'excerpt' => 'Extrait de test',
+            'content' => 'Contenu de test',
+            'thumbnail' => 'test.webp',
+            'discipline' => $discipline,
+            'year' => 2026,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+}

--- a/tests/Feature/ClubRolesPermissionsTest.php
+++ b/tests/Feature/ClubRolesPermissionsTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * Verifie le seeding des roles/permissions metier batis sur le RBAC natif
+ * d'OpenAdmin. Point cle : chaque permission metier porte un `http_path`
+ * (enforcement cote serveur) — masquer un bouton ne suffirait pas.
+ */
+class ClubRolesPermissionsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_business_permissions_carry_an_http_path_for_server_enforcement(): void
+    {
+        $articles = DB::table('admin_permissions')->where('slug', 'content.articles')->first();
+
+        $this->assertNotNull($articles, 'La permission content.articles doit exister.');
+        $this->assertStringContainsString('/posts', $articles->http_path);
+    }
+
+    public function test_each_business_role_is_seeded(): void
+    {
+        $slugs = DB::table('admin_roles')->pluck('slug')->all();
+
+        foreach (['redacteur', 'resp_partenaires', 'resp_documents', 'admin_site'] as $slug) {
+            $this->assertContains($slug, $slugs);
+        }
+    }
+
+    public function test_redacteur_is_limited_to_article_management(): void
+    {
+        $perms = $this->permissionSlugsForRole('redacteur');
+
+        $this->assertContains('content.articles', $perms);
+        // Un redacteur ne doit pas gerer les licencies ni les parametres.
+        $this->assertNotContains('club.licencies', $perms);
+        $this->assertNotContains('club.parametres', $perms);
+    }
+
+    public function test_admin_site_role_aggregates_every_business_permission(): void
+    {
+        $perms = $this->permissionSlugsForRole('admin_site');
+
+        foreach ([
+            'content.articles', 'content.partenaires', 'content.documents',
+            'sport.classements', 'club.licencies', 'club.parametres',
+        ] as $slug) {
+            $this->assertContains($slug, $perms);
+        }
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function permissionSlugsForRole(string $roleSlug): array
+    {
+        $roleId = DB::table('admin_roles')->where('slug', $roleSlug)->value('id');
+
+        return DB::table('admin_role_permissions')
+            ->join('admin_permissions', 'admin_permissions.id', '=', 'admin_role_permissions.permission_id')
+            ->where('admin_role_permissions.role_id', $roleId)
+            ->pluck('admin_permissions.slug')
+            ->all();
+    }
+}

--- a/tests/Feature/InfoBlockVisibilityTest.php
+++ b/tests/Feature/InfoBlockVisibilityTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\InfoBlock;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Verifie la regle d'affichage public des blocs d'information (scope visible) :
+ * actifs, dans leur fenetre de dates, les plus importants d'abord.
+ */
+class InfoBlockVisibilityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_only_returns_active_blocks_within_their_window(): void
+    {
+        InfoBlock::create(['titre' => 'Visible', 'niveau' => 'info', 'actif' => true]);
+        InfoBlock::create(['titre' => 'Desactive', 'niveau' => 'info', 'actif' => false]);
+        InfoBlock::create([
+            'titre' => 'Futur',
+            'niveau' => 'info',
+            'actif' => true,
+            'date_debut' => now()->addWeek()->toDateString(),
+        ]);
+        InfoBlock::create([
+            'titre' => 'Expire',
+            'niveau' => 'info',
+            'actif' => true,
+            'date_fin' => now()->subDay()->toDateString(),
+        ]);
+
+        $titres = InfoBlock::visible()->pluck('titre')->all();
+
+        $this->assertSame(['Visible'], $titres);
+    }
+
+    public function test_it_orders_by_display_order_then_recent_first(): void
+    {
+        $b = InfoBlock::create(['titre' => 'B', 'niveau' => 'info', 'actif' => true, 'ordre' => 2]);
+        $a = InfoBlock::create(['titre' => 'A', 'niveau' => 'info', 'actif' => true, 'ordre' => 1]);
+        $c = InfoBlock::create(['titre' => 'C', 'niveau' => 'info', 'actif' => true, 'ordre' => 2]);
+
+        $ids = InfoBlock::visible()->pluck('id')->all();
+
+        // ordre croissant, puis id decroissant a ordre egal (le plus recent d'abord).
+        $this->assertSame([$a->id, $c->id, $b->id], $ids);
+    }
+}

--- a/tests/Feature/PartenaireVisibilityTest.php
+++ b/tests/Feature/PartenaireVisibilityTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Partenaire;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Verifie la regle d'affichage public des partenaires (scope visible) :
+ * seuls les partenaires actifs et dans leur fenetre de partenariat sont
+ * exposes, et l'ordre d'affichage est respecte.
+ */
+class PartenaireVisibilityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_excludes_inactive_and_out_of_window_partners(): void
+    {
+        Partenaire::create(['titre' => 'Actif', 'actif' => true]);
+        Partenaire::create(['titre' => 'Inactif', 'actif' => false]);
+        Partenaire::create([
+            'titre' => 'Pas encore commence',
+            'actif' => true,
+            'date_debut' => now()->addWeek()->toDateString(),
+        ]);
+        Partenaire::create([
+            'titre' => 'Termine',
+            'actif' => true,
+            'date_fin' => now()->subDay()->toDateString(),
+        ]);
+        Partenaire::create([
+            'titre' => 'Dans la fenetre',
+            'actif' => true,
+            'date_debut' => now()->subWeek()->toDateString(),
+            'date_fin' => now()->addWeek()->toDateString(),
+        ]);
+
+        $titres = Partenaire::visible()->pluck('titre')->all();
+
+        $this->assertContains('Actif', $titres);
+        $this->assertContains('Dans la fenetre', $titres);
+        $this->assertNotContains('Inactif', $titres);
+        $this->assertNotContains('Pas encore commence', $titres);
+        $this->assertNotContains('Termine', $titres);
+    }
+
+    public function test_it_orders_by_display_order_then_id(): void
+    {
+        $second = Partenaire::create(['titre' => 'B', 'actif' => true, 'ordre' => 2]);
+        $first = Partenaire::create(['titre' => 'A', 'actif' => true, 'ordre' => 1]);
+        $third = Partenaire::create(['titre' => 'C', 'actif' => true, 'ordre' => 2]);
+
+        $ids = Partenaire::visible()->pluck('id')->all();
+
+        // ordre 1 avant ordre 2 ; a ordre egal, le plus ancien id d'abord.
+        $this->assertSame([$first->id, $second->id, $third->id], $ids);
+    }
+}


### PR DESCRIPTION
Lot 11 : renforcement des tests automatisés, checklist de tests manuels et vérifications techniques réelles.

## Tests automatisés ajoutés (4 fichiers)
- **PartenaireVisibilityTest** — le scope `visible()` exclut inactifs / hors fenêtre de dates et respecte l'ordre d'affichage.
- **InfoBlockVisibilityTest** — même logique pour les blocs d'information (actifs, dans leur fenêtre, les plus importants d'abord).
- **ClubDashboardServiceTest** — le tableau de bord n'agrège que des **données réelles** : comptage d'articles, regroupement par discipline, partenaires visibles + proches expiration.
- **ClubRolesPermissionsTest** — chaque permission métier porte un `http_path` (**enforcement serveur**), les rôles sont bien semés, le rôle *Rédacteur* est limité aux articles, *Administrateur du site* agrège toutes les permissions.

## Correctifs qualité issus de la vérification
- **Routage admin** : les contrôleurs de calendrier *par portée* (départemental/national/régional/international) ont été supprimés pour les 4 disciplines au profit du `CalendarEventController` **unifié**, mais leurs `use` et routes `resource` subsistaient → `route:list` et `route:cache` **échouaient** (classes inexistantes). Suppression de ces références mortes. De plus, les 16 combinaisons discipline×portée du contrôleur unifié partageaient le nom de route `events.*` → **collision** bloquant `route:cache` ; noms rendus **uniques** par discipline+portée. Résultat : `route:cache` repasse au vert (mise en cache des routes possible en production).
- **Lint frontend** : correction de `react-hooks/set-state-in-effect` dans `PartnersCarousel` (initialisation paresseuse ; l'effet ne fait plus que s'abonner).

## Checklist de tests manuels
Ajout de [`docs/tests-manuels.md`](../blob/test/quality-coverage/docs/tests-manuels.md) : site public (responsive, partenaires 0/1/plusieurs, logo/lien absents, clavier, mouvement réduit), admin (rôles, articles, injection, filtres documents), API (enveloppe, 422, pagination).

## Vérifications techniques réellement exécutées

| Commande | Résultat |
| --- | --- |
| `php artisan test` | ✅ **191 tests / 3044 assertions** au vert (dont les ~11 nouveaux) |
| `npm run build` (frontend) | ✅ build réussi (avertissement informatif : bundle > 500 kB, préexistant) |
| `vendor/bin/pint --test` (fichiers du lot) | ✅ conforme |
| `php artisan route:list` | ✅ 358 routes, sans exception (échouait avant) |
| `php artisan route:cache` | ✅ mise en cache réussie (échouait avant) |
| `php artisan scribe:generate` | ✅ doc + OpenAPI + Postman générés |
| `npm run lint` (frontend) | ⚠️ **3 erreurs préexistantes** subsistent (voir ci-dessous) |

### Points signalés honnêtement (non corrigés dans ce lot)
- **3 erreurs `npm run lint`** dans `ClubArchiveNav.tsx`, `ClubPosts.tsx`, `DisciplinePage.tsx` (même règle `react-hooks/set-state-in-effect`). Elles **préexistent** et touchent la logique de chargement (`setState` de `loading` en début d'effet) — leur correctif modifie un comportement et mérite son propre lot, pas un lot de tests.
- **Dérive schéma/modèle** : le modèle `Post` déclare `favoris` (fillable + `$attributes`) mais **aucune migration ne crée cette colonne** → `Post::factory()` échoue sur une base fraîche. Contourné dans les tests par insertion directe ; à corriger par une migration ajoutant `favoris`.

Aucun test n'est déclaré réussi sans avoir été exécuté.