### PR TITLE
LOT 12 — Documentation utilisateur et développeur

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,14 +251,18 @@ L’API expose toutes les données nécessaires au frontend React.
 
 ## Endpoints principaux
 
+L'API est versionnée sous le préfixe `/api/v1`.
+
 ```bash
-/api/posts
-/api/posts/{slug}
-/api/disciplines/{discipline}
-/api/calendars
-/api/calendars/{discipline}
-/api/rankings
-/api/documents
+/api/v1/public/home
+/api/v1/partenaires
+/api/v1/posts
+/api/v1/posts/slug/{slug}
+/api/v1/posts/discipline/{discipline}
+/api/v1/calendrier/{discipline}/{scope}
+/api/v1/cuescore/rankings
+/api/v1/documents/{discipline}
+/api/v1/contact
 ```
 ## Format standardisé
 
@@ -434,6 +438,18 @@ Le projet utilise Matomo auto-hébergé :
 * Event schema
 * Article schema
 * Documentation Swagger
+
+---
+
+# Documentation
+
+Documentation détaillée dans le dossier [`docs/`](docs/) :
+
+* [Guide de l'administration](docs/guide-admin.md) — pour les bénévoles non techniques (connexion, tableau de bord, articles, partenaires, documents).
+* [Documentation développeur](docs/developpeur.md) — installation, variables d'environnement, commandes, architecture, API, rôles, éditeur, tests, déploiement, retour arrière, points sensibles.
+* [Documentation de l'API](docs/api.md) — et spécification [OpenAPI](docs/openapi.yaml) (générée par Scribe, consultable sur `/docs`).
+* [Checklist de tests manuels](docs/tests-manuels.md).
+* [Étude du futur espace licencié](docs/etude-espace-licencie.md).
 
 ---
 

--- a/docs/developpeur.md
+++ b/docs/developpeur.md
@@ -1,0 +1,273 @@
+# Documentation développeur — BCJ37
+
+Documentation technique de reprise du projet. Le [README](../README.md) donne la
+vue d'ensemble ; ce document détaille l'installation, la configuration, les
+commandes, l'architecture applicative et les points sensibles.
+
+> **Aucun secret ne doit figurer dans le dépôt** ni dans cette documentation.
+> Toutes les valeurs sensibles vivent dans `.env` (non versionné).
+
+---
+
+## 1. Stack et versions
+
+| Élément | Version |
+| --- | --- |
+| PHP | ^8.1 |
+| Laravel | ^10.10 |
+| Sanctum | ^3.3 |
+| OpenAdmin (`open-admin-org/open-admin`) | ^1.0 |
+| Purifier (`mews/purifier`) | ^3.4 |
+| Scribe (`knuckleswtf/scribe`) | ^5.9 |
+| React | ^19 |
+| Vite | ^8 |
+| Base de données | MySQL (SQLite `:memory:` pour les tests) |
+
+---
+
+## 2. Installation
+
+### Backend (Laravel)
+
+```bash
+composer install
+cp .env.example .env
+php artisan key:generate
+php artisan migrate        # crée le schéma ET sème les rôles/permissions métier
+php artisan db:seed        # données de démonstration (calendriers)
+php artisan serve
+```
+
+### Frontend (React + Vite)
+
+```bash
+cd frontend
+npm install
+npm run dev                # serveur de développement
+```
+
+L'administration OpenAdmin est servie par Laravel sous `/admin`. Le frontend
+public consomme l'API `/api/v1`.
+
+---
+
+## 3. Variables d'environnement
+
+Les clés sont définies dans `.env.example`. Les principales, hors valeurs par
+défaut Laravel :
+
+| Clé | Rôle |
+| --- | --- |
+| `APP_URL`, `ADMIN_HTTPS` | URL de base ; forcer HTTPS sur les liens admin. |
+| `DB_*` | Connexion MySQL. |
+| `CACHE_DRIVER`, `QUEUE_CONNECTION` | Cache applicatif et file d'attente. |
+| `ADMIN_IMPORT_QUEUE_CONNECTION` | File dédiée aux imports déclenchés depuis l'admin (permet l'asynchrone sans changer la file globale). |
+| `MAIL_*` | Envoi de courriels (pas d'envoi automatique en production sans règle validée). |
+| `CKE5_LICENSE_KEY` | Clé de l'éditeur enrichi (voir §7). |
+| `MATOMO_URL`, `MATOMO_SITE_ID`, `MATOMO_ENABLE` | Analytics auto-hébergé (respect vie privée). |
+| `FACEBOOK_ACCESS_TOKEN`, `FACEBOOK_PAGE_ID` | Récupération d'informations de la page Facebook. |
+| `LICENSE_IMPORT_*` | Pipeline d'import des licences (source Telemat/FFBI) : identifiants, sélecteurs, seuils de validation, rétention, verrou, file. Voir §8. |
+
+> Ne jamais committer une valeur réelle pour `*_PASSWORD`, `*_TOKEN`,
+> `*_SECRET`, `*_KEY` ou `CKE5_LICENSE_KEY`.
+
+---
+
+## 4. Commandes utiles
+
+```bash
+# Tests (SQLite en mémoire)
+php artisan test
+
+# Formatage PHP (Laravel Pint)
+vendor/bin/pint            # applique
+vendor/bin/pint --test     # vérifie sans modifier
+
+# Routes
+php artisan route:list
+php artisan route:cache    # mise en cache (à valider avant déploiement)
+
+# Documentation API (Scribe)
+php artisan scribe:generate
+
+# Frontend
+cd frontend && npm run lint
+cd frontend && npm run build
+
+# Sitemap
+php artisan sitemap:generate
+
+# Import des licences (pipeline Telemat/FFBI)
+php artisan license-import:run [--source=ffbi_telemat] [--dry-run] [--triggered-by-label=...]
+php artisan license-import:scheduled-run          # variante planifiée
+
+# Classements CueScore
+php artisan cuescore:import [rankingId] [--discipline=] [--active-only] [--with-match]
+php artisan cuescore:match {fetchId}
+```
+
+---
+
+## 5. Architecture
+
+```txt
+Frontend React (Vite)  ──►  API Laravel /api/v1  ──►  MySQL
+                                   ▲
+                        Administration OpenAdmin (/admin)
+```
+
+- **Backend API-first** : le site public ne dépend d'aucune vue Blade.
+- **Frontend** : React + TypeScript, routing React Router, SEO via React Helmet.
+- **Administration** : OpenAdmin, isolée du frontend.
+
+### Conventions transverses
+
+- **Codes de discipline** (entiers) : `1` blackball, `2` carambole, `3` snooker,
+  `4` américain ; `null`/`0` = « club ». Centralisés dans
+  [`App\Support\DisciplineMapper`](../app/Support/DisciplineMapper.php).
+- **Scope `visible()`** : les modèles publics exposent un scope filtrant sur
+  `actif` + fenêtre de dates + ordre d'affichage (ex. `Partenaire`, `InfoBlock`).
+- **Invalidation du cache** : les modèles affichés en page d'accueil déclenchent
+  `ApiCacheInvalidator::publicHome()` à chaque écriture (`saved`/`deleted`).
+
+---
+
+## 6. API publique (`/api/v1`)
+
+Toutes les réponses suivent l'enveloppe standard :
+
+```json
+{ "data": …, "meta": {}, "links": [], "error": null }
+```
+
+Principaux endpoints (voir `routes/api.php` pour la liste exhaustive) :
+
+| Méthode | Chemin | Objectif |
+| --- | --- | --- |
+| GET | `/api/v1/public/home` | Données de la page d'accueil (settings, menus, partenaires, blocs info, article vedette). |
+| GET | `/api/v1/public/site` | Réglages + menus. |
+| GET | `/api/v1/partenaires` | Partenaires visibles. |
+| GET | `/api/v1/posts`, `/posts/slug/{slug}`, `/posts/discipline/{discipline}` | Articles. |
+| GET | `/api/v1/calendrier/{discipline}/{scope}` | Calendriers. |
+| GET | `/api/v1/cuescore/rankings`, `/cuescore/{discipline}/{scope}/{type}` | Classements CueScore. |
+| GET | `/api/v1/documents/{discipline}` | Documents par catégorie. |
+| POST | `/api/v1/contact` | Formulaire de contact (validation → 422 en cas d'erreur). |
+
+La documentation complète et à jour est générée par **Scribe** (`/docs`,
+`/docs.openapi`, `/docs.postman`). Voir aussi [`docs/api.md`](api.md).
+
+### Procédure lors d'un changement de route
+
+1. Modifier la route et son contrôleur.
+2. Mettre à jour les annotations Scribe si nécessaire.
+3. Régénérer : `php artisan scribe:generate`.
+4. Vérifier les **tests de contrat** (`tests/Feature/Api/ApiContractTest.php`).
+
+---
+
+## 7. Éditeur enrichi et nettoyage du HTML
+
+- Le champ d'édition des articles est enregistré via l'extension de formulaire
+  `ck5` → [`App\Admin\Extensions\Form\Ck5Decoupled`](../app/Admin/Extensions/Form/Ck5Decoupled.php).
+  **Attention au nom** : malgré « Ck5 », l'implémentation repose sur un éditeur
+  léger côté vue (`admin.form.ck5-decoupled`). L'éditeur est volontairement
+  **bridé** (pas de couleurs ni tailles arbitraires) pour préserver la charte.
+- Le contenu est **nettoyé côté serveur** par
+  [`App\Support\HtmlSanitizer::post()`](../app/Support/HtmlSanitizer.php), qui
+  applique le profil `post` de Purifier ([`config/purifier.php`](../config/purifier.php)) :
+  liste blanche de balises/attributs, schémas d'URL limités à `http`/`https`/`mailto`.
+- **Règle de sécurité** : un contenu créé dans OpenAdmin n'est pas réputé sûr. Le
+  frontend affiche du HTML brut (`dangerouslySetInnerHTML`) ; ce HTML **doit**
+  donc toujours avoir été passé par la liste blanche serveur.
+
+---
+
+## 8. Import des licences (pipeline)
+
+- Source unique : **Telemat/FFBI**, orchestrée par le pipeline DDD
+  (`TelematLicenseImportOrchestrator`) qui projette en `full_replace` vers la
+  table `licencies`.
+- Déclenchement : commande `license-import:run` (CLI) ou depuis l'admin
+  (`/admin/license-import/*`), lecture seule côté consultation des lots.
+- Les seuils de validation (`LICENSE_IMPORT_MIN_*`, `*_VARIATION_*`,
+  `*_FILL_RATE_*`) protègent contre un import dégradé : un lot hors seuils est
+  **rejeté** ou marqué en avertissement plutôt qu'activé.
+- La rétention (`LICENSE_IMPORT_KEEP_LAST_*`, `*_RETENTION_MAX_AGE_DAYS`) purge
+  les anciens lots.
+
+---
+
+## 9. Rôles et permissions
+
+Bâtis sur le **RBAC natif d'OpenAdmin** (aucun second système). Semés par la
+migration `…_seed_club_roles_and_permissions.php`. Chaque permission métier porte
+un `http_path` **appliqué côté serveur** (masquer un bouton ne suffit pas).
+
+| Rôle (slug) | Permissions |
+| --- | --- |
+| `redacteur` | articles |
+| `resp_partenaires` | partenaires |
+| `resp_documents` | documents |
+| `admin_site` | articles, partenaires, documents, classements, licenciés, paramètres |
+| `administrator` | accès total (bypass `isAdministrator`), non modifié |
+
+Le journal d'activité s'appuie sur `operation_log` (OpenAdmin), déjà activé.
+
+---
+
+## 10. Tests
+
+Suite exécutée sur SQLite en mémoire (voir `phpunit.xml`) :
+
+```bash
+php artisan test
+```
+
+Domaines couverts : contrat d'API, visibilité partenaires/blocs info,
+statistiques du tableau de bord, rôles/permissions, nettoyage HTML, pipeline
+d'import, matching CueScore. La **checklist de tests manuels** complète la suite :
+[`docs/tests-manuels.md`](tests-manuels.md).
+
+---
+
+## 11. Déploiement (o2switch)
+
+1. `git pull` sur la branche de déploiement.
+2. `composer install --no-dev --optimize-autoloader`.
+3. `php artisan migrate --force`.
+4. `php artisan config:cache && php artisan route:cache`.
+5. `php artisan scribe:generate` (si l'API a changé).
+6. Frontend : `cd frontend && npm ci && npm run build`, puis publier `dist/`.
+7. Vérifier `.env` de production (aucun secret dans le dépôt).
+
+---
+
+## 12. Retour arrière
+
+- **Code** : revenir au commit précédent (`git revert` ou redéploiement de la
+  version antérieure).
+- **Cache** : `php artisan route:clear && php artisan config:clear` si un cache
+  obsolète pose problème.
+- **Migrations** : ne pas exécuter `migrate:rollback` en production sans avoir
+  vérifié les méthodes `down()` et sans sauvegarde préalable de la base.
+- **Import de licences** : le mode `--dry-run` permet de tester sans activer un
+  lot ; la table `licencies` est reconstruite en `full_replace`, donc conserver
+  une sauvegarde avant un import de production.
+
+---
+
+## 13. Points sensibles
+
+- **HTML brut côté React** : toute nouvelle source de contenu affichée en
+  `dangerouslySetInnerHTML` doit passer par `HtmlSanitizer` (§7).
+- **Cache page d'accueil** : si un modèle affiché en home cesse d'invalider le
+  cache, les changements admin ne remontent plus — conserver le hook
+  `booted()` → `ApiCacheInvalidator`.
+- **Routes calendrier unifiées** : les 16 combinaisons discipline × portée
+  partagent le contrôleur `CalendarEventController` ; leurs noms de routes sont
+  rendus **uniques** (sinon `route:cache` échoue).
+- **Colonne `posts.favoris`** : présente dans le modèle mais absente des
+  migrations versionnées — à régulariser par une migration avant de s'appuyer
+  sur `Post::factory()` en base fraîche.
+- **Compte `administrator`** : ne jamais lui retirer le bypass ; c'est le filet
+  de sécurité contre un verrouillage accidentel des accès.

--- a/docs/guide-admin.md
+++ b/docs/guide-admin.md
@@ -1,0 +1,188 @@
+# Guide de l'administration — BCJ37
+
+Ce guide s'adresse aux **bénévoles du club** qui gèrent le site au quotidien.
+Aucune connaissance technique n'est nécessaire. L'administration est accessible à
+l'adresse **`/admin`** du site (par exemple `https://www.bcj37.fr/admin`).
+
+> En cas de doute, ne supprimez jamais un élément : préférez le **désactiver**
+> (voir plus bas). Une désactivation est réversible, une suppression ne l'est pas.
+
+---
+
+## 1. Se connecter
+
+1. Rendez-vous sur `/admin`.
+2. Saisissez votre **identifiant** et votre **mot de passe** (fournis par le
+   responsable du site).
+3. Cliquez sur **Se connecter**.
+
+Si vous avez oublié votre mot de passe, contactez le responsable du site : lui
+seul peut le réinitialiser.
+
+Pensez à vous **déconnecter** (menu en haut à droite) sur un ordinateur partagé.
+
+---
+
+## 2. Lire le tableau de bord
+
+Après connexion, la première page est le **tableau de bord**. Il rassemble les
+chiffres utiles du club :
+
+- nombre d'articles, de documents, de partenaires actifs ;
+- partenaires **bientôt expirés** (à renouveler) ;
+- prochains événements ;
+- état des derniers imports de licences.
+
+> Les chiffres affichés proviennent **uniquement de données réelles**. Lorsqu'une
+> information n'est pas encore suivie (par exemple la répartition des licenciés),
+> elle est indiquée comme telle plutôt qu'estimée. Ce n'est pas une erreur.
+
+Chaque carte est un **raccourci** : cliquez dessus pour aller directement à la
+section concernée.
+
+---
+
+## 3. Gérer les articles (actualités)
+
+### Créer un article
+
+1. Menu **Actualités** → **Ajouter**.
+2. Renseignez le **titre** (obligatoire).
+3. Rédigez le contenu dans l'**éditeur de texte** (voir §3.4).
+4. Choisissez la **discipline** concernée (ou « Le Club » pour une actualité
+   générale).
+5. Ajoutez une **image** si souhaité (voir §6).
+6. Enregistrez.
+
+### Enregistrer un brouillon vs publier
+
+- Un **brouillon** est enregistré mais **non visible** sur le site public.
+- Un article **publié** apparaît sur le site.
+- Vous pouvez repasser un article en brouillon à tout moment.
+
+### Programmer une publication
+
+Si le formulaire propose une **date de publication** future, l'article
+n'apparaîtra sur le site qu'à partir de cette date. Utile pour préparer une
+annonce à l'avance.
+
+### Utiliser l'éditeur de texte
+
+L'éditeur permet une mise en forme **simple et propre** :
+
+- paragraphes, **titres**, **gras**, *italique* ;
+- listes à puces et numérotées ;
+- liens ;
+- citations.
+
+Bonnes pratiques :
+
+- **Collez depuis Word** sans crainte : la mise en forme parasite est nettoyée
+  automatiquement.
+- N'essayez pas de forcer des couleurs ou des tailles de police : l'éditeur s'en
+  tient volontairement à la charte du site, pour un rendu homogène.
+- Utilisez les **titres** pour structurer, pas le gras seul.
+
+### Modifier un article existant
+
+Menu **Actualités** → cliquez sur l'article → modifiez → enregistrez. Les anciens
+articles restent lisibles ; vous pouvez les rééditer sans risque.
+
+---
+
+## 4. Gérer les partenaires
+
+### Ajouter un partenaire
+
+1. Menu **Partenaires** → **Ajouter**.
+2. Renseignez le **nom**, ajoutez le **logo**.
+3. **Lien (URL)** : facultatif. S'il est renseigné, le logo devient cliquable
+   sur le site et ouvre le site du partenaire dans un nouvel onglet.
+4. **Texte alternatif** : courte description du logo, utile pour l'accessibilité
+   et le référencement (ex. « Logo de la boulangerie Durand »).
+5. **Dates de début / fin** : facultatives. Elles délimitent la période
+   d'affichage du partenaire.
+6. Enregistrez.
+
+### Modifier l'ordre d'affichage
+
+Le champ **ordre** détermine la position dans le carrousel de la page d'accueil
+(plus le nombre est petit, plus le partenaire apparaît tôt). Modifiez ce nombre
+pour réorganiser.
+
+### Désactiver plutôt que supprimer
+
+- Décochez **actif** pour **retirer** un partenaire du site tout en le
+  **conservant** dans l'administration.
+- Un partenaire dont la **date de fin** est dépassée disparaît automatiquement du
+  site, sans être supprimé.
+- Ne supprimez un partenaire que si vous êtes certain de ne plus jamais en avoir
+  besoin.
+
+---
+
+## 5. Gérer les documents
+
+1. Menu **Documents** → **Ajouter**.
+2. Donnez un **titre** clair (c'est ce que verront les visiteurs).
+3. Choisissez la **catégorie** (discipline ou club) : elle sert de classement et
+   de filtre.
+4. Téléversez le fichier (PDF recommandé).
+5. Enregistrez.
+
+Dans la liste des documents, un **filtre par catégorie** et un **label** sur
+chaque ligne vous aident à retrouver rapidement un document.
+
+---
+
+## 6. Ajouter une image
+
+- Formats conseillés : **JPEG**, **PNG** ou **WebP**.
+- Préférez des images **pas trop lourdes** (idéalement moins de 1 Mo) pour ne pas
+  ralentir le site.
+- Renseignez toujours un **texte alternatif** décrivant l'image.
+- Pour les articles, une image au format **paysage** s'affiche mieux.
+
+---
+
+## 7. Blocs d'information (page d'accueil)
+
+Pour signaler une **fermeture exceptionnelle**, un **tournoi** ou une **info
+urgente** :
+
+1. Menu correspondant → **Ajouter** un bloc d'information.
+2. Renseignez **titre**, **résumé**, **niveau d'importance** (info, important,
+   urgent), **lien** facultatif.
+3. **Dates de début / fin** : le bloc s'affiche seulement pendant cette période.
+4. **Actif** : décochez pour masquer sans supprimer.
+
+---
+
+## 8. Corriger les erreurs fréquentes
+
+| Situation | Que faire |
+| --- | --- |
+| Un partenaire n'apparaît pas sur le site | Vérifiez qu'il est **actif** et que la **date de fin** n'est pas dépassée. |
+| Une image ne s'affiche pas | Vérifiez qu'elle a bien été téléversée ; réessayez avec un fichier plus léger. |
+| Un article n'est pas visible | Il est peut-être en **brouillon** ou a une **date de publication** future. |
+| Le site ne semble pas à jour | Les changements sont pris en compte immédiatement ; actualisez la page (F5). |
+| Message « champ obligatoire » | Un champ requis (souvent le **titre**) est vide : complétez-le. |
+| Un lien ne fonctionne pas | Vérifiez qu'il commence par `https://`. |
+
+En cas de blocage, notez le **message d'erreur** affiché et transmettez-le au
+responsable du site : il permet un diagnostic rapide.
+
+---
+
+## 9. Ce que vous pouvez faire selon votre rôle
+
+Chaque compte a un **rôle** qui détermine les sections accessibles :
+
+- **Rédacteur** : les actualités.
+- **Responsable partenaires** : les partenaires.
+- **Responsable documents** : les documents.
+- **Administrateur du site** : l'ensemble des contenus.
+- **Administrateur principal** : tout, y compris les réglages techniques.
+
+Si une section ne vous est pas accessible, c'est normal : votre rôle ne
+l'inclut pas. Rapprochez-vous du responsable du site si besoin.


### PR DESCRIPTION
Lot 12 : documentation destinée aux **bénévoles** (guide OpenAdmin) et aux **développeurs** (reprise du projet). Documentation uniquement — aucun code applicatif modifié.

## Guide administrateur — [`docs/guide-admin.md`](../blob/docs/user-dev-guides/docs/guide-admin.md)
Pour des utilisateurs **non techniques**, en français simple :
- se connecter, lire le tableau de bord ;
- articles : créer, **brouillon vs publication**, **programmation**, modifier, utiliser l'éditeur, coller depuis Word ;
- partenaires : ajouter, **ordre d'affichage**, **désactiver plutôt que supprimer**, dates de fin ;
- documents, images (formats/poids/texte alternatif), blocs d'information ;
- tableau des **erreurs fréquentes** et de leur correction ;
- ce que permet chaque **rôle**.

## Documentation développeur — [`docs/developpeur.md`](../blob/docs/user-dev-guides/docs/developpeur.md)
Faits **vérifiés contre le code** (versions, signatures de commandes, routes réelles) :
- stack & versions, installation back/front ;
- **variables d'environnement** (rôle de chacune, rappel « aucun secret dans le dépôt ») ;
- **commandes** (test, pint, route:cache, scribe:generate, import licences `license-import:run` / `license-import:scheduled-run`, `cuescore:import`/`cuescore:match`, sitemap) ;
- architecture et conventions (codes discipline, scope `visible()`, invalidation de cache) ;
- **API v1** (enveloppe standard, endpoints réels, procédure de changement de route) ;
- **éditeur enrichi** (`ck5` → `Ck5Decoupled`) et **nettoyage HTML** (`HtmlSanitizer` + profil `post` de Purifier) ;
- pipeline d'import des licences ;
- **rôles/permissions** (RBAC OpenAdmin, `http_path` serveur) ;
- tests, **déploiement o2switch**, **retour arrière**, **points sensibles**.

## README
- Nouvelle section **Documentation** (liens vers les guides).
- Correction du bloc des endpoints API (préfixe **`/api/v1`** réel au lieu de `/api/...`).

## Vérifications
- Documentation uniquement : **aucun code applicatif modifié**, pas de test automatisé applicable.
- Tous les **liens internes** des documents ont été vérifiés (fichiers existants).
- Aucun secret introduit dans la documentation.