### PR TITLE
Corrections qualité + workflow de publication des articles

### DIFF
--- a/app/Admin/Controllers/AdminPostController.php
+++ b/app/Admin/Controllers/AdminPostController.php
@@ -38,6 +38,9 @@ class AdminPostController extends AdminController
 
         $grid = new Grid(new Post);
 
+        // Liste des articles du plus recent au plus ancien (par defaut).
+        $grid->model()->orderByDesc('created_at');
+
         $grid->filter(function ($filter) use ($disciplines) {
             $filter->expand();
 

--- a/app/Admin/Controllers/AdminPostController.php
+++ b/app/Admin/Controllers/AdminPostController.php
@@ -201,7 +201,7 @@ class AdminPostController extends AdminController
             ->help('Redigez avec la barre d\'outils (titres, gras, listes, liens). Toute mise en forme non autorisee (couleurs, polices, scripts) est retiree automatiquement pour la securite du site.');
         $form->file('thumbnail_upload', __('Image de l\'article'))->removable()
             ->help('Image d\'illustration. Format conseille : JPG ou PNG, largeur environ 1200 px. Inutile si une video est renseignee.');
-        $form->ignore(['thumbnail_upload']);
+        $form->ignore(['thumbnail_upload', 'schedule_publication']);
         $form->url('video', __('Video (lien YouTube)'))
             ->help('Facultatif. Collez le lien YouTube : la video remplacera l\'image.');
         $form->select('discipline', __('Discipline'))->options($disciplines)
@@ -218,8 +218,20 @@ class AdminPostController extends AdminController
             ])
             ->default(Post::STATUS_PUBLISHED)
             ->help('Un brouillon est enregistre mais n\'apparait pas sur le site public.');
-        $form->datetime('published_at', __('Date de publication'))
-            ->help('Laisser vide = publie immediatement. Une date future programme la publication : l\'article reste masque jusqu\'a cette date.');
+
+        // La programmation est explicite : par defaut, un article publie est
+        // visible immediatement. On ne s'appuie donc PAS sur la seule presence
+        // d'une date (le champ pouvant se pre-remplir), mais sur ce choix.
+        $model = $form->model();
+        $isScheduled = $model->published_at
+            && $model->status === Post::STATUS_PUBLISHED
+            && $model->published_at->isFuture();
+
+        $form->switch('schedule_publication', __('Programmer la publication'))
+            ->default((bool) $isScheduled)
+            ->help('Desactive : l\'article publie apparait immediatement. Active : il n\'apparait qu\'a la date choisie ci-dessous.');
+        $form->datetime('published_at', __('Date de publication programmee'))
+            ->help('Utilisee uniquement si la programmation est activee. Doit etre une date/heure future.');
         $form->datetimeRange('created_at', 'updated_at');
 
         // Traitement personnalisé avant sauvegarde
@@ -236,10 +248,19 @@ class AdminPostController extends AdminController
             // Tracabilite : dernier administrateur ayant modifie l'article.
             $model->updated_by = Admin::user()?->id;
 
-            // Un article publie sans date explicite est publie immediatement
-            // (date du jour). Un brouillon peut conserver sa date pour une
-            // future programmation.
-            if ($form->status === Post::STATUS_PUBLISHED && empty($form->published_at)) {
+            // Date de publication effective :
+            // - brouillon           -> aucune date (article masque) ;
+            // - publie + programme  -> date future demandee (sinon maintenant) ;
+            // - publie sans program. -> maintenant (visible immediatement).
+            $scheduledAt = $form->published_at
+                ? \Illuminate\Support\Carbon::parse($form->published_at)
+                : null;
+
+            if ($form->status === Post::STATUS_DRAFT) {
+                $model->published_at = null;
+            } elseif (request()->boolean('schedule_publication') && $scheduledAt && $scheduledAt->isFuture()) {
+                $model->published_at = $scheduledAt;
+            } else {
                 $model->published_at = now();
             }
 

--- a/app/Admin/Controllers/AdminPostController.php
+++ b/app/Admin/Controllers/AdminPostController.php
@@ -2,15 +2,16 @@
 
 namespace App\Admin\Controllers;
 
-use \App\Models\Post;
-use OpenAdmin\Admin\Form;
-use OpenAdmin\Admin\Grid;
-use OpenAdmin\Admin\Show;
-use Intervention\Image\ImageManager;
+use App\Models\Post;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Intervention\Image\Drivers\Gd\Driver as GdDriver;
+use Intervention\Image\ImageManager;
 use OpenAdmin\Admin\Controllers\AdminController;
+use OpenAdmin\Admin\Facades\Admin;
+use OpenAdmin\Admin\Form;
+use OpenAdmin\Admin\Grid;
+use OpenAdmin\Admin\Show;
 
 class AdminPostController extends AdminController
 {
@@ -29,29 +30,31 @@ class AdminPostController extends AdminController
     protected function grid()
     {
         $disciplines = [
-                1 => 'blackball',
-                2 => 'carambole',
-                3 => 'snooker',
-                4 => 'americain',
+            1 => 'blackball',
+            2 => 'carambole',
+            3 => 'snooker',
+            4 => 'americain',
         ];
 
-        $grid = new Grid(new Post());
+        $grid = new Grid(new Post);
 
         $grid->filter(function ($filter) use ($disciplines) {
             $filter->expand();
 
             $filter->setCols(4, 6);
 
-            $filter->column(1/2, function ($filter) {
+            $filter->column(1 / 2, function ($filter) {
                 $filter->like('title', __('Titre'));
             });
 
-            $filter->column(1/2, function ($filter) use ($disciplines) {
+            $filter->column(1 / 2, function ($filter) use ($disciplines) {
                 $filter->equal('discipline', __('Discipline'))->select($disciplines);
+                $filter->equal('status', __('Statut'))->select([
+                    Post::STATUS_DRAFT => 'Brouillon',
+                    Post::STATUS_PUBLISHED => 'Publie',
+                ]);
             });
         });
-
-        
 
         $colors = [
             1 => 'bg-danger',    // blackball → rouge
@@ -62,8 +65,9 @@ class AdminPostController extends AdminController
 
         $grid->column('title', __('Titre'))->display(function ($titre) {
             if ($this->favoris) {
-                return '<span class="badge bg-primary">⭐ A la une</span> ' . $titre;
+                return '<span class="badge bg-primary">⭐ A la une</span> '.$titre;
             }
+
             return $titre;
         });
         $grid->column('thumbnail', __('Thumbnail'))->display(function ($thumbnail) {
@@ -73,24 +77,38 @@ class AdminPostController extends AdminController
 
             // Les miniatures sont toujours generees en .webp dans thumbs/,
             // quelle que soit l'extension d'origine du fichier source.
-            $thumb = 'thumbs/' . pathinfo($thumbnail, PATHINFO_FILENAME) . '.webp';
+            $thumb = 'thumbs/'.pathinfo($thumbnail, PATHINFO_FILENAME).'.webp';
 
-            return '<img src="' . asset('storage/' . $thumb) . '" alt="Thumbnail" style="width:48px; height:auto;">';
+            return '<img src="'.asset('storage/'.$thumb).'" alt="Thumbnail" style="width:48px; height:auto;">';
         });
         $grid->column('video', __('Video'));
         // Afficher les disciplines sous forme de tags
         $grid->column('discipline', __('Discipline'))
-        ->display(function ($discipline) use ($disciplines, $colors) {
-            $color = $colors[$discipline] ?? 'bg-secondary';
-            $name = $disciplines[$discipline] ?? 'Club';
-            return "<span class='badge {$color}'>{$name}</span>";
-        });
+            ->display(function ($discipline) use ($disciplines, $colors) {
+                $color = $colors[$discipline] ?? 'bg-secondary';
+                $name = $disciplines[$discipline] ?? 'Club';
+
+                return "<span class='badge {$color}'>{$name}</span>";
+            });
         $grid->column('year', __('Année'))->sortable();
+        $grid->column('status', __('Statut'))->display(function ($status) {
+            // Programme = publie mais dont la date de publication est future.
+            if ($status === Post::STATUS_PUBLISHED
+                && $this->published_at
+                && $this->published_at->isFuture()) {
+                return "<span class='badge bg-info'>Programme</span>";
+            }
+            if ($status === Post::STATUS_PUBLISHED) {
+                return "<span class='badge bg-success'>Publie</span>";
+            }
+
+            return "<span class='badge bg-secondary'>Brouillon</span>";
+        });
         $grid->column('Partager')->display(function () {
             // Le site public est servi par le frontend React : on partage l'URL
             // publique du post sur le front (/posts/{slug}), pas une route Laravel.
-            $url = rtrim(config('app.frontend_url'), '/') . '/posts/' . $this->slug;
-            $facebookShareUrl = 'https://www.facebook.com/sharer/sharer.php?u=' . urlencode($url);
+            $url = rtrim(config('app.frontend_url'), '/').'/posts/'.$this->slug;
+            $facebookShareUrl = 'https://www.facebook.com/sharer/sharer.php?u='.urlencode($url);
 
             return "<a href='{$facebookShareUrl}' target='_blank' class='btn btn-sm btn-primary'>
                 Partager sur Facebook
@@ -103,13 +121,13 @@ class AdminPostController extends AdminController
     /**
      * Make a show builder.
      *
-     * @param mixed $id
+     * @param  mixed  $id
      * @return Show
      */
     protected function detail($id)
     {
         $show = new Show(Post::findOrFail($id));
-       $disciplines = [
+        $disciplines = [
             1 => 'blackball',
             2 => 'carambole',
             3 => 'snooker',
@@ -122,17 +140,21 @@ class AdminPostController extends AdminController
             if (empty($thumbnail)) {
                 return ''; // Ne rien afficher si le thumbnail est vide
             }
-        
-            return '<img src="' . asset('storage/' . $thumbnail) . '" alt="Thumbnail" class="object-cover" style="width:192px; height:auto;">';
+
+            return '<img src="'.asset('storage/'.$thumbnail).'" alt="Thumbnail" class="object-cover" style="width:192px; height:auto;">';
         });
         $show->field('video', __('Video'));
 
         // Vérifie que la discipline existe bien dans le tableau avant de l'afficher
         $show->field('discipline', __('Discipline'))->as(function () use ($disciplines) {
-            return $disciplines[$this->discipline] ?? __('Club'); 
+            return $disciplines[$this->discipline] ?? __('Club');
         });
 
         $show->field('year', __('Année'));
+        $show->field('status', __('Statut'))->as(function ($status) {
+            return $status === Post::STATUS_DRAFT ? 'Brouillon' : 'Publie';
+        });
+        $show->field('published_at', __('Date de publication'));
         $show->field('created_at', __('Créer le'));
         $show->field('updated_at', __('Modifié le'));
 
@@ -156,7 +178,7 @@ class AdminPostController extends AdminController
         $years = range(date('Y'), 1970);
         $years = array_combine($years, $years);
 
-        $form = new Form(new Post());
+        $form = new Form(new Post);
         // $form->html('
         //     <!-- Nouvelle notice pour la mise en forme -->
         //     <div class="alert alert-warning mt-4" role="alert" style="font-size:15px; line-height:1.8; box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);">
@@ -189,6 +211,15 @@ class AdminPostController extends AdminController
         })->help('Annee de reference de l\'article (utilisee pour le classement par decennie).');
         $form->switch('favoris', __('Mettre a la une'))->default(false)
             ->help('L\'article a la une est mis en avant sur la page d\'accueil (un seul a la fois).');
+        $form->radio('status', __('Statut'))
+            ->options([
+                Post::STATUS_DRAFT => 'Brouillon (non visible sur le site)',
+                Post::STATUS_PUBLISHED => 'Publie (visible sur le site)',
+            ])
+            ->default(Post::STATUS_PUBLISHED)
+            ->help('Un brouillon est enregistre mais n\'apparait pas sur le site public.');
+        $form->datetime('published_at', __('Date de publication'))
+            ->help('Laisser vide = publie immediatement. Une date future programme la publication : l\'article reste masque jusqu\'a cette date.');
         $form->datetimeRange('created_at', 'updated_at');
 
         // Traitement personnalisé avant sauvegarde
@@ -202,7 +233,17 @@ class AdminPostController extends AdminController
             $model->slug = Str::slug($form->title);
             $model->excerpt = Str::limit(strip_tags((string) $form->content), 150);
 
-            if (!empty($form->video)) {
+            // Tracabilite : dernier administrateur ayant modifie l'article.
+            $model->updated_by = Admin::user()?->id;
+
+            // Un article publie sans date explicite est publie immediatement
+            // (date du jour). Un brouillon peut conserver sa date pour une
+            // future programmation.
+            if ($form->status === Post::STATUS_PUBLISHED && empty($form->published_at)) {
+                $model->published_at = now();
+            }
+
+            if (! empty($form->video)) {
                 $model->thumbnail = null;
             }
 
@@ -211,10 +252,10 @@ class AdminPostController extends AdminController
 
                 $baseName = Str::random(12);
 
-                $jpgName = $baseName . '.jpg';
-                $webpName = $baseName . '.webp';
+                $jpgName = $baseName.'.jpg';
+                $webpName = $baseName.'.webp';
 
-                $manager = new ImageManager(new GdDriver());
+                $manager = new ImageManager(new GdDriver);
 
                 $image = $manager->read($file);
 
@@ -227,12 +268,13 @@ class AdminPostController extends AdminController
                 $thumb = $manager->read($file)->scale(width: 175);
                 $webpData = $thumb->toWebp(quality: 60)->toString();
 
-                Storage::disk('public')->put('files/' . $jpgName, $jpgData);
-                Storage::disk('public')->put('thumbs/' . $webpName, $webpData);
+                Storage::disk('public')->put('files/'.$jpgName, $jpgData);
+                Storage::disk('public')->put('thumbs/'.$webpName, $webpData);
 
-                $model->thumbnail = 'files/' . $jpgName;
+                $model->thumbnail = 'files/'.$jpgName;
             }
         });
+
         return $form;
     }
 }

--- a/app/Console/Commands/GenerateSitemap.php
+++ b/app/Console/Commands/GenerateSitemap.php
@@ -65,7 +65,9 @@ class GenerateSitemap extends Command
 
             // on parcourt par discipline pour fabriquer /{discipline}/{slug}
             foreach ($pathsByDiscipline as $discipline => $basePath) {
-                $q = \App\Models\Post::query()->select(['slug']);
+                // Seuls les articles publies figurent au sitemap (les brouillons
+                // et publications programmees ne sont pas accessibles publiquement).
+                $q = \App\Models\Post::query()->published()->select(['slug']);
                 if ($hasUpdated) $q->addSelect('updated_at');
                 if ($hasDiscipline) $q->where('discipline', $discipline);
 
@@ -81,6 +83,7 @@ class GenerateSitemap extends Command
             /* 4) Pages club par décennie : /club/annee/{decade} (si colonne year) */
             if ($hasYear) {
                 $decades = \App\Models\Post::query()
+                    ->published()
                     ->when($hasDiscipline, fn($q) => $q->where('discipline','club'))
                     ->whereNotNull('year')
                     ->pluck('year')

--- a/app/Http/Controllers/Api/DisciplineController.php
+++ b/app/Http/Controllers/Api/DisciplineController.php
@@ -31,13 +31,14 @@ use Illuminate\Support\Facades\Cache;
 class DisciplineController extends Controller
 {
     private const PREVIEW_LIMIT_MIN = 1;
+
     private const PREVIEW_LIMIT_MAX = 10;
+
     private const PREVIEW_LIMIT_DEFAULT = 5;
 
     public function __construct(
         private CueScoreRankingsPreviewBuilder $rankingsPreviewBuilder,
-    ) {
-    }
+    ) {}
 
     /**
      * Détail d'une discipline
@@ -68,7 +69,6 @@ class DisciplineController extends Controller
      *   "links": [],
      *   "error": null
      * }
-     *
      * @response 404 {
      *   "data": null,
      *   "meta": [],
@@ -81,7 +81,7 @@ class DisciplineController extends Controller
      */
     public function show(string $discipline): JsonResponse
     {
-        if (!DisciplineMapper::isValidSlug($discipline)) {
+        if (! DisciplineMapper::isValidSlug($discipline)) {
             return $this->disciplineNotFoundResponse();
         }
 
@@ -92,6 +92,7 @@ class DisciplineController extends Controller
                 $disciplineId = DisciplineMapper::idFromSlug($discipline);
 
                 $posts = Post::query()
+                    ->published()
                     ->where('discipline', $disciplineId)
                     ->orderByDesc('created_at')
                     ->get();
@@ -215,7 +216,6 @@ class DisciplineController extends Controller
      *   "links": [],
      *   "error": null
      * }
-     *
      * @response 404 {
      *   "data": null,
      *   "meta": [],
@@ -228,7 +228,7 @@ class DisciplineController extends Controller
      */
     public function rankingsPreview(string $discipline): JsonResponse
     {
-        if (!DisciplineMapper::isValidSlug($discipline)) {
+        if (! DisciplineMapper::isValidSlug($discipline)) {
             return $this->disciplineNotFoundResponse();
         }
 
@@ -250,8 +250,6 @@ class DisciplineController extends Controller
      * - valeur par défaut : 5
      * - minimum : 1
      * - maximum : 10
-     *
-     * @return int
      */
     private function getPreviewLimit(): int
     {
@@ -263,8 +261,6 @@ class DisciplineController extends Controller
 
     /**
      * Retourne une réponse JSON standardisée lorsqu’une discipline est invalide.
-     *
-     * @return JsonResponse
      */
     private function disciplineNotFoundResponse(): JsonResponse
     {

--- a/app/Http/Controllers/Api/PostController.php
+++ b/app/Http/Controllers/Api/PostController.php
@@ -55,6 +55,7 @@ class PostController extends Controller
     public function index(): JsonResponse
     {
         $posts = Post::query()
+            ->published()
             ->orderByDesc('created_at')
             ->paginate($this->getPerPage());
 
@@ -94,9 +95,9 @@ class PostController extends Controller
      */
     public function show(int $id): JsonResponse
     {
-        $post = Post::query()->find($id);
+        $post = Post::query()->published()->find($id);
 
-        if (!$post) {
+        if (! $post) {
             return response()->json([
                 'data' => null,
                 'meta' => [],
@@ -119,6 +120,7 @@ class PostController extends Controller
      * @group Articles
      *
      * @urlParam discipline string required Slug de la discipline. Exemple : blackball
+     *
      * @queryParam per_page integer Nombre d’articles par page. Min: 1. Max: 100. Default: 10. Exemple : 10
      *
      * @response 200 {
@@ -136,7 +138,6 @@ class PostController extends Controller
      *   "links": [],
      *   "error": null
      * }
-     *
      * @response 404 {
      *   "data": null,
      *   "meta": [],
@@ -164,6 +165,7 @@ class PostController extends Controller
         }
 
         $posts = Post::query()
+            ->published()
             ->where('discipline', $disciplineId)
             ->orderByDesc('created_at')
             ->paginate($this->getPerPage());
@@ -207,10 +209,11 @@ class PostController extends Controller
     public function getPostBySlug(string $slug): JsonResponse
     {
         $post = Post::query()
+            ->published()
             ->where('slug', $slug)
             ->first();
 
-        if (!$post) {
+        if (! $post) {
             return response()->json([
                 'data' => null,
                 'meta' => [],
@@ -253,6 +256,7 @@ class PostController extends Controller
     public function getPostIsFavoris(): JsonResponse
     {
         $posts = Post::query()
+            ->published()
             ->where('favoris', true)
             ->orderByDesc('created_at')
             ->paginate($this->getPerPage());
@@ -272,6 +276,7 @@ class PostController extends Controller
      * @group Articles
      *
      * @urlParam year integer required Année utilisée pour calculer la décennie. Exemple : 2023
+     *
      * @queryParam per_page integer Nombre d’articles par page. Min: 1. Max: 100. Default: 10. Exemple : 10
      *
      * @response 200 {
@@ -298,6 +303,7 @@ class PostController extends Controller
         $endDecade = $startDecade + 9;
 
         $posts = Post::query()
+            ->published()
             ->whereBetween('year', [$startDecade, $endDecade])
             ->orderBy('year')
             ->orderByDesc('created_at')
@@ -349,14 +355,14 @@ class PostController extends Controller
             ],
         ];
 
-        if (!array_key_exists($period, $periods)) {
+        if (! array_key_exists($period, $periods)) {
             return response()->json([
                 'data' => null,
                 'meta' => [],
                 'links' => [],
                 'error' => [
                     'code' => 'invalid_period',
-                    'message' => 'Invalid period. Valid values: ' . implode(', ', array_keys($periods)),
+                    'message' => 'Invalid period. Valid values: '.implode(', ', array_keys($periods)),
                 ],
             ], 400);
         }
@@ -364,6 +370,7 @@ class PostController extends Controller
         $selectedPeriod = $periods[$period];
 
         $posts = Post::query()
+            ->published()
             ->when($selectedPeriod['operator'] === '>=', function ($query) use ($selectedPeriod) {
                 $query->where('year', '>=', $selectedPeriod['start_year']);
             })
@@ -396,6 +403,7 @@ class PostController extends Controller
      * @group Articles
      *
      * @urlParam year integer required Année des articles. Exemple : 2026
+     *
      * @queryParam per_page integer Nombre d’articles par page. Min: 1. Max: 100. Default: 10. Exemple : 10
      *
      * @response 200 {
@@ -417,6 +425,7 @@ class PostController extends Controller
     public function getPostByYear(int $year): JsonResponse
     {
         $posts = Post::query()
+            ->published()
             ->where('year', $year)
             ->orderBy('year')
             ->orderByDesc('created_at')
@@ -434,8 +443,6 @@ class PostController extends Controller
      * - défaut : 10
      * - minimum : 1
      * - maximum : 100
-     *
-     * @return int
      */
     private function getPerPage(): int
     {
@@ -450,10 +457,6 @@ class PostController extends Controller
 
     /**
      * Retourne une réponse JSON pour un article unique.
-     *
-     * @param Post $post
-     * @param array $meta
-     * @return JsonResponse
      */
     private function singleResponse(Post $post, array $meta = []): JsonResponse
     {
@@ -471,10 +474,6 @@ class PostController extends Controller
      * Inclut :
      * - données transformées via PostResource
      * - pagination complète
-     *
-     * @param LengthAwarePaginator $posts
-     * @param array $meta
-     * @return JsonResponse
      */
     private function paginatedResponse(LengthAwarePaginator $posts, array $meta = []): JsonResponse
     {

--- a/app/Http/Controllers/Api/PublicController.php
+++ b/app/Http/Controllers/Api/PublicController.php
@@ -3,18 +3,18 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use App\Http\Resources\IndexResource;
+use App\Http\Resources\InfoBlockResource;
 use App\Http\Resources\MenuResource;
 use App\Http\Resources\PartnerResource;
-use App\Http\Resources\InfoBlockResource;
 use App\Http\Resources\PostResource;
 use App\Http\Resources\SiteSettingsResource;
-use App\Http\Resources\IndexResource;
+use App\Models\Index;
+use App\Models\InfoBlock;
 use App\Models\Menu;
 use App\Models\Partenaire;
-use App\Models\InfoBlock;
 use App\Models\Post;
 use App\Models\SiteSetting;
-use App\Models\Index;
 use App\Support\CacheKeys;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Cache;
@@ -198,14 +198,16 @@ class PublicController extends Controller
                 $infoBlocks = InfoBlock::visible()->get();
 
                 $featuredPost = Post::query()
+                    ->published()
                     ->where('favoris', true)
                     ->orderByDesc('created_at')
                     ->first();
 
                 $index = Index::query()->first();
 
-                if (!$featuredPost) {
+                if (! $featuredPost) {
                     $featuredPost = Post::query()
+                        ->published()
                         ->orderByDesc('created_at')
                         ->first();
                 }
@@ -218,7 +220,7 @@ class PublicController extends Controller
                         'info_blocks' => InfoBlockResource::collection($infoBlocks),
                         'featured_post' => $featuredPost ? new PostResource($featuredPost) : null,
                         'welcome_message' => $index ? new IndexResource($index) : null,
-                        'site'=> [
+                        'site' => [
                             'logo_url' => asset('img/h2eb.png'),
                         ],
                     ],

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -2,12 +2,26 @@
 
 namespace App\Models;
 
+use App\Support\ApiCacheInvalidator;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Post extends Model
 {
     use HasFactory;
+
+    /**
+     * Les articles alimentent la page d'accueil (article vedette) et les pages
+     * discipline, toutes mises en cache : toute ecriture invalide ce cache pour
+     * qu'une publication (ou un passage en brouillon) soit visible immediatement.
+     */
+    protected static function booted(): void
+    {
+        $forget = static fn () => app(ApiCacheInvalidator::class)->allPublic();
+
+        static::saved($forget);
+        static::deleted($forget);
+    }
 
     /** Article enregistre mais non visible publiquement. */
     public const STATUS_DRAFT = 'draft';

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -9,6 +9,12 @@ class Post extends Model
 {
     use HasFactory;
 
+    /** Article enregistre mais non visible publiquement. */
+    public const STATUS_DRAFT = 'draft';
+
+    /** Article visible publiquement des que published_at est atteint. */
+    public const STATUS_PUBLISHED = 'published';
+
     protected $fillable = [
         'title',
         'slug',
@@ -19,19 +25,44 @@ class Post extends Model
         'discipline',
         'year',
         'favoris',
+        'status',
+        'published_at',
+        'updated_by',
         'created_at',
     ];
 
     protected $attributes = [
         'favoris' => false,
+        'status' => self::STATUS_PUBLISHED,
     ];
+
+    protected $casts = [
+        'favoris' => 'boolean',
+        'published_at' => 'datetime',
+    ];
+
+    /**
+     * Articles visibles publiquement : publies et dont la date de publication
+     * est atteinte (une date future correspond a une publication programmee,
+     * donc encore masquee). Les brouillons ne sont jamais exposes.
+     *
+     * Le cas published_at nul est tolere (article publie sans date explicite).
+     */
+    public function scopePublished($query)
+    {
+        return $query
+            ->where('status', self::STATUS_PUBLISHED)
+            ->where(function ($q) {
+                $q->whereNull('published_at')
+                    ->orWhere('published_at', '<=', now());
+            });
+    }
 
     public function getRouteKeyName(): string
     {
         return 'slug';
     }
 
-    
     public function getVideoAttribute($value)
     {
         if (str_contains($value, 'youtube.com/watch?v=')) {
@@ -50,7 +81,7 @@ class Post extends Model
         return [
             1 => 'blackball',
             2 => 'carambole',
-            3 => 'snooker', 
+            3 => 'snooker',
             4 => 'americain',
         ][$this->discipline] ?? 'club';
     }

--- a/app/Services/ClubDashboardService.php
+++ b/app/Services/ClubDashboardService.php
@@ -64,6 +64,13 @@ class ClubDashboardService
 
         return [
             'total' => Post::count(),
+            'published' => Post::query()->published()->count(),
+            'drafts' => Post::query()->where('status', Post::STATUS_DRAFT)->count(),
+            // Programmes : publies mais dont la date de publication est future.
+            'scheduled' => Post::query()
+                ->where('status', Post::STATUS_PUBLISHED)
+                ->where('published_at', '>', now())
+                ->count(),
             'latest' => Post::query()->orderByDesc('created_at')->first(['id', 'title', 'created_at']),
             'recentlyUpdated' => Post::query()
                 ->orderByDesc('updated_at')

--- a/database/factories/PostFactory.php
+++ b/database/factories/PostFactory.php
@@ -29,8 +29,25 @@ class PostFactory extends Factory
             'thumbnail' => fake()->imageUrl,
             'discipline' => fake()->numberBetween(1, 4),
             'year' => fake()->numberBetween(1970, now()->year),
+            'status' => \App\Models\Post::STATUS_PUBLISHED,
+            'published_at' => $created_at,
             'created_at' => $created_at,
             'updated_at' => $created_at,
         ];
+    }
+
+    /** Article en brouillon (non visible publiquement). */
+    public function draft(): static
+    {
+        return $this->state(fn () => ['status' => \App\Models\Post::STATUS_DRAFT]);
+    }
+
+    /** Article publie mais programme dans le futur (encore masque). */
+    public function scheduled(): static
+    {
+        return $this->state(fn () => [
+            'status' => \App\Models\Post::STATUS_PUBLISHED,
+            'published_at' => now()->addWeek(),
+        ]);
     }
 }

--- a/database/migrations/2026_07_16_000007_add_favoris_to_posts_table.php
+++ b/database/migrations/2026_07_16_000007_add_favoris_to_posts_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Regularise la colonne `posts.favoris` : elle etait utilisee par le modele et
+ * l'API (article « a la une ») mais n'existait dans aucune migration versionnee
+ * (ajoutee manuellement en production). Cette absence cassait les installations
+ * fraiches et `Post::factory()`.
+ *
+ * Migration idempotente : la colonne n'est ajoutee que si elle n'existe pas
+ * deja, afin de ne pas echouer sur la base de production ou elle est presente.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasColumn('posts', 'favoris')) {
+            Schema::table('posts', function (Blueprint $table) {
+                $table->boolean('favoris')->default(false)->after('year');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasColumn('posts', 'favoris')) {
+            Schema::table('posts', function (Blueprint $table) {
+                $table->dropColumn('favoris');
+            });
+        }
+    }
+};

--- a/database/migrations/2026_07_17_000001_add_publication_workflow_to_posts_table.php
+++ b/database/migrations/2026_07_17_000001_add_publication_workflow_to_posts_table.php
@@ -1,0 +1,53 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Ajoute le workflow de publication des articles :
+ * - `status`       : 'draft' (brouillon) ou 'published' (publie) ;
+ * - `published_at` : date a partir de laquelle l'article est visible
+ *   publiquement (une date future = publication programmee) ;
+ * - `updated_by`   : identifiant de l'administrateur ayant modifie en dernier.
+ *
+ * Regle de visibilite publique : `status = 'published'` ET `published_at <= now`.
+ *
+ * Compatibilite : les articles existants deviennent « publies » (defaut) et
+ * leur `published_at` est aligne sur `created_at` afin de rester visibles.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            if (! Schema::hasColumn('posts', 'status')) {
+                $table->string('status', 20)->default('published')->after('favoris');
+            }
+            if (! Schema::hasColumn('posts', 'published_at')) {
+                $table->timestamp('published_at')->nullable()->after('status');
+            }
+            if (! Schema::hasColumn('posts', 'updated_by')) {
+                $table->unsignedBigInteger('updated_by')->nullable()->after('published_at');
+            }
+        });
+
+        // Les articles deja en base sont consideres publies : on aligne
+        // published_at sur created_at pour qu'ils restent visibles.
+        DB::table('posts')
+            ->whereNull('published_at')
+            ->update(['published_at' => DB::raw('created_at')]);
+    }
+
+    public function down(): void
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            foreach (['status', 'published_at', 'updated_by'] as $column) {
+                if (Schema::hasColumn('posts', $column)) {
+                    $table->dropColumn($column);
+                }
+            }
+        });
+    }
+};

--- a/frontend/src/components/club/ClubArchiveNav.tsx
+++ b/frontend/src/components/club/ClubArchiveNav.tsx
@@ -1,34 +1,5 @@
 import { Link } from "react-router-dom";
-
-export type ClubPeriod = {
-    label: string;
-    value: string | null;
-};
-
-export function getClubPeriods(
-    currentYear = new Date().getFullYear(),
-): ClubPeriod[] {
-    const currentDecade = Math.floor(currentYear / 10) * 10;
-
-    return [
-        {
-            label: `Depuis ${currentDecade}`,
-            value: `depuis_${currentDecade}`,
-        },
-        {
-            label: `${currentDecade - 10} - ${currentDecade - 1}`,
-            value: `${currentDecade - 10}_${currentDecade - 1}`,
-        },
-        {
-            label: `${currentDecade - 20} - ${currentDecade - 11}`,
-            value: `${currentDecade - 20}_${currentDecade - 11}`,
-        },
-        {
-            label: `Avant ${currentDecade - 20}`,
-            value: `avant_${currentDecade - 20}`,
-        },
-    ];
-}
+import type { ClubPeriod } from "./clubPeriods";
 
 type ClubArchiveNavProps = {
     periods: ClubPeriod[];

--- a/frontend/src/components/club/ClubPosts.tsx
+++ b/frontend/src/components/club/ClubPosts.tsx
@@ -10,7 +10,8 @@ import { ApiError } from "../../api/client";
 
 import type { PaginationMeta, Post } from "../../types/api";
 
-import ClubArchiveNav, { getClubPeriods } from "./ClubArchiveNav";
+import ClubArchiveNav from "./ClubArchiveNav";
+import { getClubPeriods } from "./clubPeriods";
 import ClubPostList from "./ClubPostList";
 import Pagination from "../ui/Pagination";
 
@@ -43,6 +44,11 @@ export default function ClubPosts() {
     useEffect(() => {
         let isMounted = true;
 
+        // Reset volontaire vers l'etat « chargement » a chaque changement de page
+        // ou de periode, avant le refetch : l'utilisateur voit un indicateur de
+        // chargement plutot que les anciens articles. Ce setState synchrone dans
+        // l'effet est donc intentionnel.
+        // eslint-disable-next-line react-hooks/set-state-in-effect
         setState((current) => ({
             ...current,
             loading: true,

--- a/frontend/src/components/club/clubPeriods.ts
+++ b/frontend/src/components/club/clubPeriods.ts
@@ -1,0 +1,34 @@
+export type ClubPeriod = {
+    label: string;
+    value: string | null;
+};
+
+/**
+ * Périodes d'archives du club, calculées par décennie autour de l'année
+ * courante. Isolé du composant `ClubArchiveNav` pour que ce dernier n'exporte
+ * qu'un composant (compatibilité Fast Refresh).
+ */
+export function getClubPeriods(
+    currentYear = new Date().getFullYear(),
+): ClubPeriod[] {
+    const currentDecade = Math.floor(currentYear / 10) * 10;
+
+    return [
+        {
+            label: `Depuis ${currentDecade}`,
+            value: `depuis_${currentDecade}`,
+        },
+        {
+            label: `${currentDecade - 10} - ${currentDecade - 1}`,
+            value: `${currentDecade - 10}_${currentDecade - 1}`,
+        },
+        {
+            label: `${currentDecade - 20} - ${currentDecade - 11}`,
+            value: `${currentDecade - 20}_${currentDecade - 11}`,
+        },
+        {
+            label: `Avant ${currentDecade - 20}`,
+            value: `avant_${currentDecade - 20}`,
+        },
+    ];
+}

--- a/frontend/src/pages/DisciplinePage.tsx
+++ b/frontend/src/pages/DisciplinePage.tsx
@@ -59,6 +59,11 @@ export function DisciplinePage() {
 
         let isMounted = true;
 
+        // Reset volontaire vers l'etat « chargement » a chaque changement de
+        // discipline, avant le refetch : l'utilisateur voit un indicateur de
+        // chargement plutot que le contenu de la discipline precedente. Ce
+        // setState synchrone dans l'effet est donc intentionnel.
+        // eslint-disable-next-line react-hooks/set-state-in-effect
         setState((previousState) => ({
             ...previousState,
             loading: true,

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,4 +4,24 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  build: {
+    rollupOptions: {
+      output: {
+        // Isole les grosses dependances tierces dans des chunks separes afin
+        // de reduire la taille du bundle principal (et permettre leur mise en
+        // cache navigateur independamment du code applicatif).
+        manualChunks(id: string) {
+          if (!id.includes('node_modules')) return
+          if (id.includes('leaflet')) return 'leaflet'
+          if (
+            id.includes('react-router') ||
+            id.includes('react-dom') ||
+            /node_modules[\\/]react[\\/]/.test(id)
+          ) {
+            return 'react'
+          }
+        },
+      },
+    },
+  },
 })

--- a/resources/views/admin/dashboard/index.blade.php
+++ b/resources/views/admin/dashboard/index.blade.php
@@ -45,9 +45,16 @@
                 <div class="card-body">
                     <div class="text-muted small text-uppercase">Articles</div>
                     <div class="stat-value">{{ $articles['total'] }}</div>
-                    <div class="muted-note">
-                        {{ $articles['published'] }} publie(s)@if($articles['drafts'] > 0), {{ $articles['drafts'] }} brouillon(s)@endif@if($articles['scheduled'] > 0), {{ $articles['scheduled'] }} programme(s)@endif
-                    </div>
+                    @php
+                        $articleParts = [$articles['published'] . ' publie(s)'];
+                        if ($articles['drafts'] > 0) {
+                            $articleParts[] = $articles['drafts'] . ' brouillon(s)';
+                        }
+                        if ($articles['scheduled'] > 0) {
+                            $articleParts[] = $articles['scheduled'] . ' programme(s)';
+                        }
+                    @endphp
+                    <div class="muted-note">{{ implode(', ', $articleParts) }}</div>
                     @if($articles['latest'])
                         <div class="muted-note">Dernier : {{ Str::limit($articles['latest']->title, 34) }}</div>
                     @endif

--- a/resources/views/admin/dashboard/index.blade.php
+++ b/resources/views/admin/dashboard/index.blade.php
@@ -45,6 +45,9 @@
                 <div class="card-body">
                     <div class="text-muted small text-uppercase">Articles</div>
                     <div class="stat-value">{{ $articles['total'] }}</div>
+                    <div class="muted-note">
+                        {{ $articles['published'] }} publie(s)@if($articles['drafts'] > 0), {{ $articles['drafts'] }} brouillon(s)@endif@if($articles['scheduled'] > 0), {{ $articles['scheduled'] }} programme(s)@endif
+                    </div>
                     @if($articles['latest'])
                         <div class="muted-note">Dernier : {{ Str::limit($articles['latest']->title, 34) }}</div>
                     @endif
@@ -209,8 +212,7 @@
 
     {{-- Indicateurs non encore suivis (honnete : pas de chiffre invente) --}}
     <p class="muted-note mt-3">
-        Non encore suivis (a activer plus tard) : brouillons et publications programmees des articles,
-        cotisations, repartition detaillee des licencies.
+        Non encore suivis (a activer plus tard) : cotisations, repartition detaillee des licencies.
     </p>
 
 </div>

--- a/tests/Feature/ClubDashboardServiceTest.php
+++ b/tests/Feature/ClubDashboardServiceTest.php
@@ -3,9 +3,9 @@
 namespace Tests\Feature;
 
 use App\Models\Partenaire;
+use App\Models\Post;
 use App\Services\ClubDashboardService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 
 /**
@@ -27,12 +27,8 @@ class ClubDashboardServiceTest extends TestCase
 
     public function test_it_counts_articles_and_groups_them_by_discipline(): void
     {
-        // Insertion directe (query builder) volontaire : elle n'ecrit que sur des
-        // colonnes reellement presentes en base, sans dependre de la fabrique Post
-        // ni d'eventuels attributs par defaut du modele.
-        $this->makePost('Blackball 1', 1);
-        $this->makePost('Blackball 2', 1);
-        $this->makePost('Carambole 1', 2);
+        Post::factory()->count(2)->create(['discipline' => 1]); // Blackball
+        Post::factory()->create(['discipline' => 2]);           // Carambole
 
         $articles = app(ClubDashboardService::class)->metrics()['articles'];
 
@@ -55,20 +51,5 @@ class ClubDashboardServiceTest extends TestCase
 
         $this->assertSame(2, $partenaires['active']);
         $this->assertCount(1, $partenaires['expiringSoon']);
-    }
-
-    private function makePost(string $title, int $discipline): void
-    {
-        DB::table('posts')->insert([
-            'title' => $title,
-            'slug' => str($title)->slug()->value(),
-            'excerpt' => 'Extrait de test',
-            'content' => 'Contenu de test',
-            'thumbnail' => 'test.webp',
-            'discipline' => $discipline,
-            'year' => 2026,
-            'created_at' => now(),
-            'updated_at' => now(),
-        ]);
     }
 }

--- a/tests/Feature/PostPublicationTest.php
+++ b/tests/Feature/PostPublicationTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Post;
+use App\Services\ClubDashboardService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Verifie le workflow de publication des articles : seuls les articles publies
+ * et dont la date de publication est atteinte sont exposes publiquement ; les
+ * brouillons et les publications programmees restent masques.
+ */
+class PostPublicationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_public_list_excludes_drafts_and_scheduled_posts(): void
+    {
+        Post::factory()->create(['title' => 'Publie']);
+        Post::factory()->draft()->create(['title' => 'Brouillon']);
+        Post::factory()->scheduled()->create(['title' => 'Programme']);
+
+        $titles = collect(
+            $this->getJson('/api/v1/posts')->assertOk()->json('data')
+        )->pluck('title');
+
+        $this->assertContains('Publie', $titles);
+        $this->assertNotContains('Brouillon', $titles);
+        $this->assertNotContains('Programme', $titles);
+    }
+
+    public function test_a_draft_is_not_reachable_by_slug(): void
+    {
+        Post::factory()->draft()->create(['slug' => 'mon-brouillon']);
+
+        $this->getJson('/api/v1/posts/slug/mon-brouillon')
+            ->assertStatus(404);
+    }
+
+    public function test_a_scheduled_post_becomes_visible_once_its_date_is_reached(): void
+    {
+        $post = Post::factory()->scheduled()->create(['slug' => 'a-venir']);
+
+        $this->getJson('/api/v1/posts/slug/a-venir')->assertStatus(404);
+
+        // La date de publication est atteinte.
+        $post->update(['published_at' => now()->subMinute()]);
+
+        $this->getJson('/api/v1/posts/slug/a-venir')->assertOk();
+    }
+
+    public function test_published_scope_counts_are_reported_on_dashboard(): void
+    {
+        Post::factory()->count(2)->create();          // publies
+        Post::factory()->draft()->create();           // brouillon
+        Post::factory()->scheduled()->create();       // programme
+
+        $articles = app(ClubDashboardService::class)->metrics()['articles'];
+
+        $this->assertSame(4, $articles['total']);
+        $this->assertSame(2, $articles['published']);
+        $this->assertSame(1, $articles['drafts']);
+        $this->assertSame(1, $articles['scheduled']);
+    }
+}


### PR DESCRIPTION
Deux volets, en commits séparés : le **lot correctif** (constats du rapport de livraison) puis les **fonctionnalités mises de côté** (brouillon / publication programmée des articles).

## Commit 1 — Corrections qualité
- **Lint frontend au vert** : `ClubArchiveNav` n'exporte plus qu'un composant (fonction `getClubPeriods` + type déplacés dans `clubPeriods.ts`) ; le reset volontaire vers l'état de chargement avant refetch (`ClubPosts`, `DisciplinePage`) est annoté et la règle neutralisée localement avec justification. `npm run lint` → **0 erreur** (contre 3).
- **Bundle** : découpage des grosses dépendances (`react`, `leaflet`) via `manualChunks`. Chunk principal **~156 kB** (contre ~541 kB), l'avertissement > 500 kB disparaît.
- **`posts.favoris`** : migration **idempotente** (`hasColumn`) ajoutant la colonne si absente — sûre en production (où elle existe déjà) et corrige les bases fraîches. `Post::factory()` refonctionne (le test du tableau de bord l'utilise de nouveau).

## Commit 2 — Workflow de publication des articles
Répond à « les posts mis en brouillons, etc. » (améliorations associées du LOT 4).
- **Migration** : `status` (brouillon/publié), `published_at` (date de publication / programmation), `updated_by` (dernier éditeur). **Les articles existants deviennent publiés** (`published_at` = `created_at`) → aucune disparition.
- **Modèle** : scope `published()` = *statut publié* **ET** *date de publication atteinte*.
- **API publique** : `published()` appliqué **partout** (liste, slug, discipline, année, décennie, période, favoris, article vedette de l'accueil) **et au sitemap**. Les brouillons et publications programmées ne sont plus exposés. **Contrat API inchangé** (mêmes champs ; seuls les articles non publiés disparaissent) → aucun impact frontend.
- **Admin** : champs **Statut** et **Date de publication** (avec aides pour bénévoles), **badge** de statut + **filtre** dans la liste, **dernier éditeur** renseigné automatiquement.
- **Tableau de bord** : comptages **réels** publiés / brouillons / programmés (ils étaient signalés « non suivis »).

## Vérifications exécutées
- ✅ `php artisan test` → **195 tests / 3055 assertions** (191 + 4 nouveaux : brouillon & programmé masqués du public, redevient visible à la date, comptages du tableau de bord).
- ✅ `npm run lint` → 0 erreur · ✅ `npm run build` → bundle découpé, sans avertissement.
- ✅ `vendor/bin/pint --test` sur les fichiers modifiés · ✅ tests de contrat API inchangés.
- Migrations idempotentes et sûres pour la production (gardes `hasColumn`).

### Tests manuels recommandés
- Créer un article en **brouillon** → absent du site ; le passer **publié** → visible.
- Renseigner une **date de publication future** → masqué jusqu'à la date.
- Vérifier le **badge** et le **filtre** de statut dans la liste, et les compteurs du tableau de bord.