### PR TITLE
Éditeur d'article : aperçu + avertissement modifications non enregistrées

### DIFF
--- a/app/Admin/Controllers/AdminPostController.php
+++ b/app/Admin/Controllers/AdminPostController.php
@@ -191,12 +191,16 @@ class AdminPostController extends AdminController
             && $model->status === Post::STATUS_PUBLISHED
             && $model->published_at->isFuture();
 
+        // Image deja enregistree, exposee pour l'apercu (cas de l'edition sans
+        // re-televersement). Le JS d'apercu la lit via .bcj-current-thumb.
+        $currentThumbUrl = $model->thumbnail ? asset('storage/'.$model->thumbnail) : '';
+
         // Champs auxiliaires non stockes directement sur le modele.
         $form->ignore(['thumbnail_upload', 'schedule_publication']);
 
         // Formulaire organise en onglets pour rester lisible par des benevoles
         // non techniques : le contenu, puis le classement, puis la publication.
-        $form->tab(__('Contenu'), function ($form) {
+        $form->tab(__('Contenu'), function ($form) use ($currentThumbUrl) {
             $form->text('title', __('Titre de l\'article'))->required()
                 ->help('Titre affiche sur le site public.');
             $form->ck5('content', __('Contenu'))->rows(700)
@@ -205,6 +209,7 @@ class AdminPostController extends AdminController
                 ->help('Image d\'illustration. Format conseille : JPG ou PNG, largeur environ 1200 px. Inutile si une video est renseignee.');
             $form->url('video', __('Video (lien YouTube)'))
                 ->help('Facultatif. Collez le lien YouTube : la video remplacera l\'image.');
+            $form->html('<input type="hidden" class="bcj-current-thumb" value="'.e($currentThumbUrl).'">');
         }, true);
 
         $form->tab(__('Classement'), function ($form) use ($disciplines, $years) {

--- a/app/Admin/bootstrap.php
+++ b/app/Admin/bootstrap.php
@@ -10,6 +10,10 @@ Form::extend('ck5', Ck5Decoupled::class);
 // les variables Bootstrap). Voir public/css/admin-bcj.css.
 Admin::css('/css/admin-bcj.css');
 
+// Ameliorations UX admin : avertissement "modifications non enregistrees" et
+// apercu d'article. Voir public/js/admin-bcj.js.
+Admin::js('/js/admin-bcj.js');
+
 // Quill (CSS + JS)
 Admin::css('https://cdn.jsdelivr.net/npm/quill@1.3.7/dist/quill.snow.css');
 Admin::js('https://cdn.jsdelivr.net/npm/quill@1.3.7/dist/quill.min.js');

--- a/public/css/admin-bcj.css
+++ b/public/css/admin-bcj.css
@@ -316,6 +316,87 @@ a:focus-visible,
     text-decoration: underline;
 }
 
+/* Champ technique masque : l'URL de l'image existante n'est la que pour
+   l'apercu (lue par le JS), pas pour l'utilisateur. On masque sa ligne. */
+.form-group:has(.bcj-current-thumb) {
+    display: none;
+}
+
+/* Media (image / video) de l'apercu. */
+.bcj-preview__media {
+    margin: 0 0 1.2rem;
+}
+
+.bcj-preview__image {
+    display: block;
+    max-width: 100%;
+    height: auto;
+    border-radius: 6px;
+}
+
+/* Video en ratio 16:9 responsive. */
+.bcj-preview__video {
+    position: relative;
+    padding-top: 56.25%;
+}
+
+.bcj-preview__video iframe {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    border: 0;
+    border-radius: 6px;
+}
+
+/* ------------------------------------------------------------------ */
+/* Modale de confirmation (charte du club, centree)                   */
+/* ------------------------------------------------------------------ */
+
+.bcj-modal-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 2100;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 16px;
+    background: rgba(8, 35, 79, 0.55);
+}
+
+.bcj-modal-overlay[hidden] {
+    display: none;
+}
+
+.bcj-modal {
+    width: 100%;
+    max-width: 460px;
+    background: #fff;
+    border-radius: 8px;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
+    overflow: hidden;
+}
+
+.bcj-modal__bar {
+    padding: 0.8rem 1.1rem;
+    background: var(--bcj-gradient);
+    color: #fff;
+    font-weight: 700;
+}
+
+.bcj-modal__body {
+    padding: 1.2rem 1.1rem;
+    color: #1f2937;
+    line-height: 1.5;
+}
+
+.bcj-modal__actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.6rem;
+    padding: 0 1.1rem 1.1rem;
+}
+
 /* ------------------------------------------------------------------ */
 /* Ecran de connexion                                                 */
 /* ------------------------------------------------------------------ */

--- a/public/css/admin-bcj.css
+++ b/public/css/admin-bcj.css
@@ -205,6 +205,118 @@ a:focus-visible,
 }
 
 /* ------------------------------------------------------------------ */
+/* Apercu de l'article (modale)                                       */
+/* ------------------------------------------------------------------ */
+
+.oa-ck5-actions {
+    text-align: right;
+    margin-bottom: 0.5rem;
+}
+
+.bcj-preview-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 2000;
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    padding: 4vh 16px;
+    background: rgba(8, 35, 79, 0.55);
+    overflow-y: auto;
+}
+
+.bcj-preview-overlay[hidden] {
+    display: none;
+}
+
+.bcj-preview {
+    width: 100%;
+    max-width: 820px;
+    background: #fff;
+    border-radius: 8px;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
+    overflow: hidden;
+}
+
+.bcj-preview__bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.6rem 1rem;
+    background: var(--bcj-gradient);
+    color: #fff;
+}
+
+.bcj-preview__tag {
+    font-weight: 700;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+    font-size: 0.8rem;
+}
+
+.bcj-preview__close {
+    background: transparent;
+    border: 0;
+    color: #fff;
+    font-size: 1.6rem;
+    line-height: 1;
+    cursor: pointer;
+    padding: 0 0.3rem;
+}
+
+.bcj-preview__body {
+    padding: 1.5rem 1.8rem 2rem;
+}
+
+.bcj-preview__title {
+    margin: 0 0 1rem;
+    font-size: 1.8rem;
+    color: var(--bcj-blue-dark);
+}
+
+.bcj-preview__content {
+    color: #1f2937;
+    line-height: 1.6;
+}
+
+.bcj-preview__content h2 {
+    font-size: 1.4rem;
+    margin: 1.2rem 0 0.6rem;
+}
+
+.bcj-preview__content h3 {
+    font-size: 1.2rem;
+    margin: 1rem 0 0.5rem;
+}
+
+.bcj-preview__content h4 {
+    font-size: 1.05rem;
+    margin: 0.9rem 0 0.5rem;
+}
+
+.bcj-preview__content p {
+    margin: 0 0 0.8rem;
+}
+
+.bcj-preview__content ul,
+.bcj-preview__content ol {
+    margin: 0 0 0.8rem 1.4rem;
+}
+
+.bcj-preview__content blockquote {
+    margin: 0 0 0.8rem;
+    padding: 0.4rem 1rem;
+    border-left: 3px solid var(--bcj-pink);
+    color: #475569;
+    font-style: italic;
+}
+
+.bcj-preview__content a {
+    color: var(--bcj-blue);
+    text-decoration: underline;
+}
+
+/* ------------------------------------------------------------------ */
 /* Ecran de connexion                                                 */
 /* ------------------------------------------------------------------ */
 

--- a/public/js/admin-bcj.js
+++ b/public/js/admin-bcj.js
@@ -3,23 +3,67 @@
  * Charge via Admin::js('/js/admin-bcj.js').
  *
  *  1. Avertissement avant de quitter une page d'edition/creation avec des
- *     modifications non enregistrees (fermeture d'onglet, rafraichissement,
- *     navigation interne).
- *  2. Apercu de l'article (titre + contenu) dans une fenetre modale.
+ *     modifications non enregistrees.
+ *  2. Apercu de l'article (titre + media + contenu) dans une fenetre modale.
  *
  * Fonctionne avec la navigation PJAX d'OpenAdmin grace a une delegation
- * d'evenements posee une seule fois sur `document` (aucune re-initialisation
- * necessaire apres un changement de page).
+ * d'evenements posee une seule fois sur `document`.
  */
 (function () {
   'use strict';
+
+  /* ---------------------------------------------------------------- */
+  /* Modale de confirmation (charte du site, centree)                 */
+  /* ---------------------------------------------------------------- */
+
+  function bcjConfirm(onConfirm) {
+    var el = document.getElementById('bcj-confirm-overlay');
+    if (!el) {
+      el = document.createElement('div');
+      el.id = 'bcj-confirm-overlay';
+      el.className = 'bcj-modal-overlay';
+      el.hidden = true;
+      el.innerHTML =
+        '<div class="bcj-modal" role="alertdialog" aria-modal="true" aria-labelledby="bcj-confirm-title">' +
+          '<div class="bcj-modal__bar" id="bcj-confirm-title">Modifications non enregistrees</div>' +
+          '<div class="bcj-modal__body">' +
+            'Vous avez des modifications non enregistrees sur cette page.<br>' +
+            'Voulez-vous vraiment la quitter&nbsp;? Vos changements seront perdus.' +
+          '</div>' +
+          '<div class="bcj-modal__actions">' +
+            '<button type="button" class="btn btn-light bcj-modal__cancel">Rester sur la page</button>' +
+            '<button type="button" class="btn btn-primary bcj-modal__ok">Quitter sans enregistrer</button>' +
+          '</div>' +
+        '</div>';
+      document.body.appendChild(el);
+    }
+
+    var okBtn = el.querySelector('.bcj-modal__ok');
+    var cancelBtn = el.querySelector('.bcj-modal__cancel');
+
+    function onKey(e) { if (e.key === 'Escape') close(); }
+    function close() {
+      el.hidden = true;
+      okBtn.onclick = null;
+      cancelBtn.onclick = null;
+      el.onclick = null;
+      document.removeEventListener('keydown', onKey);
+    }
+
+    okBtn.onclick = function () { close(); onConfirm(); };
+    cancelBtn.onclick = close;
+    el.onclick = function (e) { if (e.target === el) close(); };
+    document.addEventListener('keydown', onKey);
+
+    el.hidden = false;
+    cancelBtn.focus();
+  }
 
   /* ---------------------------------------------------------------- */
   /* 1) Avertissement "modifications non enregistrees"                */
   /* ---------------------------------------------------------------- */
 
   var dirty = false;
-  var MSG = 'Vous avez des modifications non enregistrees. Voulez-vous vraiment quitter cette page sans enregistrer ?';
 
   // On ne surveille que les pages de creation / edition (URL en /create ou
   // /edit) et jamais le formulaire de recherche de la barre laterale.
@@ -37,11 +81,13 @@
   document.addEventListener('change', function (e) { if (inEditForm(e.target)) dirty = true; }, true);
   document.addEventListener('submit', function (e) { if (inEditForm(e.target)) dirty = false; }, true);
 
+  // Fermeture d'onglet / rafraichissement : dialogue natif du navigateur
+  // (impossible a personnaliser, impose par le navigateur pour raisons de securite).
   window.addEventListener('beforeunload', function (e) {
     if (dirty) { e.preventDefault(); e.returnValue = ''; }
   });
 
-  // Navigation interne (liens, menu, PJAX) : confirmer avant de perdre les modifs.
+  // Navigation interne (liens, menu, PJAX) : modale de confirmation stylee.
   document.addEventListener('click', function (e) {
     if (!dirty) return;
     var a = e.target.closest ? e.target.closest('a[href]') : null;
@@ -50,20 +96,44 @@
     if (href === '' || href.charAt(0) === '#' || href.indexOf('javascript:') === 0) return;
     if (a.getAttribute('target') === '_blank' || a.hasAttribute('download')) return;
 
-    if (window.confirm(MSG)) {
-      dirty = false; // l'utilisateur accepte de quitter
-    } else {
-      e.preventDefault();
-      e.stopPropagation();
-      e.stopImmediatePropagation();
-    }
+    var dest = a.href; // URL absolue resolue
+    e.preventDefault();
+    e.stopPropagation();
+    e.stopImmediatePropagation();
+
+    bcjConfirm(function () {
+      dirty = false;
+      window.location.href = dest;
+    });
   }, true);
 
   /* ---------------------------------------------------------------- */
   /* 2) Apercu de l'article                                           */
   /* ---------------------------------------------------------------- */
 
-  function ensureModal() {
+  // Convertit une URL YouTube (watch / youtu.be) en URL d'integration, comme
+  // le fait le backend. Retourne l'URL telle quelle si non reconnue.
+  function toEmbedUrl(url) {
+    if (!url) return '';
+    var m = url.match(/watch\?v=([a-zA-Z0-9_-]+)/);
+    if (m) return 'https://www.youtube.com/embed/' + m[1];
+    m = url.match(/youtu\.be\/([a-zA-Z0-9_-]+)/);
+    if (m) return 'https://www.youtube.com/embed/' + m[1];
+    return url;
+  }
+
+  // Image a previsualiser : la nouvelle image selectionnee en priorite, sinon
+  // l'image deja enregistree (exposee par le formulaire).
+  function currentImageUrl() {
+    var fileInput = document.querySelector('input[type="file"]');
+    if (fileInput && fileInput.files && fileInput.files[0]) {
+      return URL.createObjectURL(fileInput.files[0]);
+    }
+    var existing = document.querySelector('.bcj-current-thumb');
+    return existing && existing.value ? existing.value : '';
+  }
+
+  function ensurePreviewModal() {
     var overlay = document.getElementById('bcj-preview-overlay');
     if (overlay) return overlay;
 
@@ -79,6 +149,7 @@
         '</div>' +
         '<article class="bcj-preview__body rich-text">' +
           '<h1 class="bcj-preview__title"></h1>' +
+          '<div class="bcj-preview__media"></div>' +
           '<div class="bcj-preview__content"></div>' +
         '</article>' +
       '</div>';
@@ -94,18 +165,33 @@
   }
 
   function openPreview() {
-    var overlay = ensureModal();
-    var titleInput = document.querySelector('input[name="title"]');
+    var overlay = ensurePreviewModal();
 
-    // Le contenu vit dans l'editeur Quill : on lit sa zone editable a la volee
-    // (le textarea n'est synchronise que sur certains evenements).
+    // Titre.
+    var titleInput = document.querySelector('input[name="title"]');
+    overlay.querySelector('.bcj-preview__title').textContent =
+      (titleInput && titleInput.value.trim()) ? titleInput.value.trim() : '(Titre a renseigner)';
+
+    // Media : la video (si renseignee) remplace l'image, comme sur le site public.
+    var videoInput = document.querySelector('input[name="video"]');
+    var videoUrl = videoInput ? toEmbedUrl(videoInput.value.trim()) : '';
+    var media = '';
+    if (videoUrl) {
+      media = '<div class="bcj-preview__video"><iframe src="' + videoUrl +
+              '" title="Video de l\'article" frameborder="0" ' +
+              'allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture" ' +
+              'allowfullscreen></iframe></div>';
+    } else {
+      var img = currentImageUrl();
+      if (img) media = '<img class="bcj-preview__image" src="' + img + '" alt="">';
+    }
+    overlay.querySelector('.bcj-preview__media').innerHTML = media;
+
+    // Contenu : lu a la volee dans l'editeur Quill.
     var ta = document.querySelector('textarea[name="content"]');
     var wrap = ta ? ta.closest('.oa-ck5-wrapper') : null;
     var editor = wrap ? wrap.querySelector('.ql-editor') : null;
     var html = editor ? editor.innerHTML : (ta ? ta.value : '');
-
-    overlay.querySelector('.bcj-preview__title').textContent =
-      (titleInput && titleInput.value.trim()) ? titleInput.value.trim() : '(Titre a renseigner)';
     overlay.querySelector('.bcj-preview__content').innerHTML =
       (html && html.trim()) ? html : '<p><em>Aucun contenu pour le moment.</em></p>';
 

--- a/public/js/admin-bcj.js
+++ b/public/js/admin-bcj.js
@@ -1,0 +1,121 @@
+/*
+ * Ameliorations UX de l'administration BCJ37 (vanilla JS, sans dependance).
+ * Charge via Admin::js('/js/admin-bcj.js').
+ *
+ *  1. Avertissement avant de quitter une page d'edition/creation avec des
+ *     modifications non enregistrees (fermeture d'onglet, rafraichissement,
+ *     navigation interne).
+ *  2. Apercu de l'article (titre + contenu) dans une fenetre modale.
+ *
+ * Fonctionne avec la navigation PJAX d'OpenAdmin grace a une delegation
+ * d'evenements posee une seule fois sur `document` (aucune re-initialisation
+ * necessaire apres un changement de page).
+ */
+(function () {
+  'use strict';
+
+  /* ---------------------------------------------------------------- */
+  /* 1) Avertissement "modifications non enregistrees"                */
+  /* ---------------------------------------------------------------- */
+
+  var dirty = false;
+  var MSG = 'Vous avez des modifications non enregistrees. Voulez-vous vraiment quitter cette page sans enregistrer ?';
+
+  // On ne surveille que les pages de creation / edition (URL en /create ou
+  // /edit) et jamais le formulaire de recherche de la barre laterale.
+  function onEditPage() {
+    return /\/(create|edit)\/?$/.test(window.location.pathname);
+  }
+
+  function inEditForm(el) {
+    if (!onEditPage() || !el || !el.closest) return false;
+    var form = el.closest('form');
+    return !!form && !form.classList.contains('sidebar-form');
+  }
+
+  document.addEventListener('input', function (e) { if (inEditForm(e.target)) dirty = true; }, true);
+  document.addEventListener('change', function (e) { if (inEditForm(e.target)) dirty = true; }, true);
+  document.addEventListener('submit', function (e) { if (inEditForm(e.target)) dirty = false; }, true);
+
+  window.addEventListener('beforeunload', function (e) {
+    if (dirty) { e.preventDefault(); e.returnValue = ''; }
+  });
+
+  // Navigation interne (liens, menu, PJAX) : confirmer avant de perdre les modifs.
+  document.addEventListener('click', function (e) {
+    if (!dirty) return;
+    var a = e.target.closest ? e.target.closest('a[href]') : null;
+    if (!a) return;
+    var href = a.getAttribute('href') || '';
+    if (href === '' || href.charAt(0) === '#' || href.indexOf('javascript:') === 0) return;
+    if (a.getAttribute('target') === '_blank' || a.hasAttribute('download')) return;
+
+    if (window.confirm(MSG)) {
+      dirty = false; // l'utilisateur accepte de quitter
+    } else {
+      e.preventDefault();
+      e.stopPropagation();
+      e.stopImmediatePropagation();
+    }
+  }, true);
+
+  /* ---------------------------------------------------------------- */
+  /* 2) Apercu de l'article                                           */
+  /* ---------------------------------------------------------------- */
+
+  function ensureModal() {
+    var overlay = document.getElementById('bcj-preview-overlay');
+    if (overlay) return overlay;
+
+    overlay = document.createElement('div');
+    overlay.id = 'bcj-preview-overlay';
+    overlay.className = 'bcj-preview-overlay';
+    overlay.hidden = true;
+    overlay.innerHTML =
+      '<div class="bcj-preview" role="dialog" aria-modal="true" aria-label="Apercu de l\'article">' +
+        '<div class="bcj-preview__bar">' +
+          '<span class="bcj-preview__tag">Apercu</span>' +
+          '<button type="button" class="bcj-preview__close" aria-label="Fermer l\'apercu">&times;</button>' +
+        '</div>' +
+        '<article class="bcj-preview__body rich-text">' +
+          '<h1 class="bcj-preview__title"></h1>' +
+          '<div class="bcj-preview__content"></div>' +
+        '</article>' +
+      '</div>';
+    document.body.appendChild(overlay);
+
+    var close = function () { overlay.hidden = true; };
+    overlay.querySelector('.bcj-preview__close').addEventListener('click', close);
+    overlay.addEventListener('click', function (e) { if (e.target === overlay) close(); });
+    document.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape' && !overlay.hidden) close();
+    });
+    return overlay;
+  }
+
+  function openPreview() {
+    var overlay = ensureModal();
+    var titleInput = document.querySelector('input[name="title"]');
+
+    // Le contenu vit dans l'editeur Quill : on lit sa zone editable a la volee
+    // (le textarea n'est synchronise que sur certains evenements).
+    var ta = document.querySelector('textarea[name="content"]');
+    var wrap = ta ? ta.closest('.oa-ck5-wrapper') : null;
+    var editor = wrap ? wrap.querySelector('.ql-editor') : null;
+    var html = editor ? editor.innerHTML : (ta ? ta.value : '');
+
+    overlay.querySelector('.bcj-preview__title').textContent =
+      (titleInput && titleInput.value.trim()) ? titleInput.value.trim() : '(Titre a renseigner)';
+    overlay.querySelector('.bcj-preview__content').innerHTML =
+      (html && html.trim()) ? html : '<p><em>Aucun contenu pour le moment.</em></p>';
+
+    overlay.hidden = false;
+  }
+
+  document.addEventListener('click', function (e) {
+    var btn = e.target.closest ? e.target.closest('.bcj-preview-btn') : null;
+    if (!btn) return;
+    e.preventDefault();
+    openPreview();
+  });
+})();

--- a/resources/views/admin/form/ck5-decoupled.blade.php
+++ b/resources/views/admin/form/ck5-decoupled.blade.php
@@ -1,6 +1,14 @@
 @include('admin::form.error')
 
 <div class="oa-ck5-wrapper" id="{{ $id }}_wrap">
+  {{-- Bouton d'apercu : ouvre le rendu de l'article (titre + contenu) en modale.
+       La logique est dans public/js/admin-bcj.js (classe .bcj-preview-btn). --}}
+  <div class="oa-ck5-actions">
+    <button type="button" class="btn btn-sm btn-outline-primary bcj-preview-btn">
+      Aperçu de l'article
+    </button>
+  </div>
+
   <div class="editor-container editor-container_document-editor">
     {{-- Zone principale : toolbar + page --}}
     <div class="editor-container__main">


### PR DESCRIPTION
Dernières améliorations associées de l'éditeur d'article (LOT 4), en **JS vanilla sans dépendance**, chargé via `Admin::js('/js/admin-bcj.js')`.

## 1. Avertissement « modifications non enregistrées »
Sur les pages de **création** et **d'édition**, dès qu'un champ est modifié, un garde-fou est armé :
- **fermeture d'onglet / rafraîchissement / navigation externe** → dialogue natif du navigateur ;
- **clic sur un lien, le menu, navigation PJAX** → confirmation avant de perdre les modifications ;
- **soumission du formulaire** → garde-fou désarmé (pas d'avertissement intempestif à l'enregistrement).

Implémentation par **délégation d'événements sur `document`** (posée une seule fois) → robuste à la navigation PJAX d'OpenAdmin, sans ré-initialisation. Limité aux URL `/create` et `/edit`, la barre latérale de recherche est exclue.

## 2. Aperçu de l'article
Un bouton **« Aperçu de l'article »** au-dessus de l'éditeur ouvre une **modale** affichant le **titre** et le **contenu** (lu à la volée dans l'éditeur Quill) avec une mise en forme proche du rendu public (titres, listes, citations, liens). Fermeture par la croix, un clic à l'extérieur ou la touche **Échap**. Accessible (`role="dialog"`, `aria-modal`).

## Fichiers
- `public/js/admin-bcj.js` (nouveau) — les deux comportements.
- `resources/views/admin/form/ck5-decoupled.blade.php` — bouton d'aperçu.
- `public/css/admin-bcj.css` — styles de la modale.
- `app/Admin/bootstrap.php` — enregistrement du script.

Aucune modification du package OpenAdmin ; aucune dépendance JS ajoutée.

## Vérifications exécutées
- ✅ Rendu de la page de création **testé via requête admin authentifiée** → HTTP 200, présence du bouton (`bcj-preview-btn`) et du script (`/js/admin-bcj.js`). Test jetable, retiré ensuite.
- ✅ `php artisan test` → **195 tests / 3055 assertions**.
- ✅ CSS équilibré.

### Tests manuels recommandés (comportement JS, non couvert par les tests)
1. Éditer un article, modifier un champ, tenter de cliquer sur un menu / fermer l'onglet → l'avertissement doit apparaître ; enregistrer ne doit **pas** déclencher d'avertissement.
2. Cliquer sur « Aperçu de l'article » → la modale affiche titre + contenu ; fermeture croix / extérieur / Échap.