### PR TITLE
chore : ignorer le dossier deploy/ (scripts locaux)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ yarn-error.log
 /.idea
 /.vscode
 /docs/conception
+/deploy


### PR DESCRIPTION
Ajoute `/deploy` au `.gitignore`.

Les scripts de déploiement (`deploy.ps1`, `remote.sh`, `winscp-upload.txt`, `front.htaccess`, `README.md`) contiennent des **coordonnées serveur** propres à l'environnement (hôte, utilisateur, chemins) et ne doivent **pas être versionnés** sur le dépôt public. On les conserve en **local**.

Ainsi, un futur `git add .` ne les re-committera pas par accident.