### PR TITLE
Dashboard : accès rapides vers le site public et Matomo

### DIFF
--- a/resources/views/admin/dashboard/index.blade.php
+++ b/resources/views/admin/dashboard/index.blade.php
@@ -30,12 +30,35 @@
 
 <div class="dashboard-bcj">
 
+    {{-- Liens externes (front public + statistiques Matomo). Bases sur la config
+         (app.frontend_url, matomo.url) : s'adaptent automatiquement selon
+         l'environnement (test / production). --}}
+    @php
+        $frontUrl = rtrim((string) config('app.frontend_url'), '/');
+        $matomoBase = rtrim((string) config('matomo.url'), '/');
+        $matomoUrl = $matomoBase
+            ? $matomoBase.'/index.php?module=CoreHome&action=index&idSite='.config('matomo.site_id').'&period=day&date=today'
+            : null;
+    @endphp
+
     {{-- Raccourcis vers les principales actions --}}
     <div class="d-flex flex-wrap gap-2 mb-4">
         <a class="btn btn-primary btn-sm" href="{{ admin_url('posts/create') }}"><i class="icon-plus"></i> Nouvel article</a>
         <a class="btn btn-outline-primary btn-sm" href="{{ admin_url('partenaires/create') }}"><i class="icon-plus"></i> Nouveau partenaire</a>
         <a class="btn btn-outline-primary btn-sm" href="{{ admin_url('documents/create') }}"><i class="icon-plus"></i> Nouveau document</a>
         <a class="btn btn-outline-secondary btn-sm" href="{{ admin_url('license-import/batches') }}">Imports des licenciés</a>
+
+        {{-- Acces externes (nouvel onglet) --}}
+        @if($frontUrl)
+            <a class="btn btn-outline-dark btn-sm" href="{{ $frontUrl }}" target="_blank" rel="noopener noreferrer">
+                <i class="icon-external-link"></i> Voir le site
+            </a>
+        @endif
+        @if($matomoUrl)
+            <a class="btn btn-outline-dark btn-sm" href="{{ $matomoUrl }}" target="_blank" rel="noopener noreferrer">
+                <i class="icon-external-link"></i> Statistiques (Matomo)
+            </a>
+        @endif
     </div>
 
     {{-- Cartes chiffres cles : chaque carte mene a sa section --}}


### PR DESCRIPTION
Ajoute deux accès rapides dans les raccourcis du tableau de bord d'administration, en préparation du déploiement sur `bcj37.fr`.

## Ce que ça ajoute
- **« Voir le site »** → le front public (`config('app.frontend_url')`).
- **« Statistiques (Matomo) »** → le tableau de bord Matomo du site (`config('matomo.url')` + `config('matomo.site_id')`), **affiché uniquement si Matomo est configuré**.

## Points clés
- **Basé sur la configuration** (`FRONTEND_URL`, `MATOMO_URL`, `MATOMO_SITE_ID`) → les liens s'adaptent **automatiquement** : `test.alexandrebourlier.fr` aujourd'hui, `bcj37.fr` / `api.bcj37.fr` en production, sans modifier le code (juste le `.env`).
- Ouverture en **nouvel onglet** avec `rel="noopener noreferrer"`.
- Le lien Matomo pointe directement sur le tableau de bord du site (`idSite`, période du jour).

## Vérifications
- ✅ Vue Blade compilée sans erreur (`php -l` sur le compilé).
- ✅ Rendu du dashboard **testé** (requête admin) → HTTP 200, présence de « Voir le site », « Statistiques (Matomo) » et de l'`idSite` correct.

## Rappel config production (bcj37.fr)
Dans le `.env.production` du serveur de prod, il faudra :
- `FRONTEND_URL=https://bcj37.fr`
- `APP_URL=https://api.bcj37.fr`
- `MATOMO_URL=` (l'URL de ton instance Matomo) · `MATOMO_SITE_ID=` (l'id du site bcj37)
puis `php artisan config:cache`.