### PR TITLE
Front : bandeau de consentement cookies + Matomo conditionné (opt-in)

### DIFF
--- a/frontend/src/components/analytics/MatomoTracker.tsx
+++ b/frontend/src/components/analytics/MatomoTracker.tsx
@@ -1,0 +1,23 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+import { trackPageView } from "../../lib/matomo";
+
+/**
+ * Envoie une vue de page a Matomo a chaque changement de route (application
+ * SPA). N'a aucun effet tant que le visiteur n'a pas accepte la mesure
+ * d'audience (voir lib/matomo). Ne rend rien.
+ */
+export function MatomoTracker() {
+    const location = useLocation();
+
+    useEffect(() => {
+        // Le titre est mis a jour par react-helmet ; on laisse un court delai
+        // pour capturer le bon titre de page.
+        const id = window.setTimeout(() => {
+            trackPageView(location.pathname + location.search, document.title);
+        }, 0);
+        return () => window.clearTimeout(id);
+    }, [location]);
+
+    return null;
+}

--- a/frontend/src/components/cookies/CookieBanner.tsx
+++ b/frontend/src/components/cookies/CookieBanner.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { getConsent, setConsent, OPEN_SETTINGS_EVENT } from "../../lib/consent";
+import { initMatomo, trackPageView } from "../../lib/matomo";
+import "../../styles/cookieBanner.css";
+
+/**
+ * Bandeau de consentement aux cookies de mesure d'audience (opt-in).
+ *
+ * - Affiche uniquement si aucun choix valide n'est memorise.
+ * - « Accepter » active Matomo immediatement et enregistre la vue courante.
+ * - « Refuser » n'active rien.
+ * - Reouvrable depuis le pied de page (« Gerer les cookies »).
+ */
+export function CookieBanner() {
+    // Etat initial calcule une fois (lecture du choix memorise) : le bandeau
+    // s'affiche si aucun choix valide n'est enregistre.
+    const [visible, setVisible] = useState(() => getConsent() === null);
+
+    useEffect(() => {
+        const open = () => setVisible(true);
+        window.addEventListener(OPEN_SETTINGS_EVENT, open);
+        return () => window.removeEventListener(OPEN_SETTINGS_EVENT, open);
+    }, []);
+
+    if (!visible) return null;
+
+    const accept = () => {
+        setConsent("accepted");
+        initMatomo();
+        trackPageView(window.location.pathname + window.location.search, document.title);
+        setVisible(false);
+    };
+
+    const refuse = () => {
+        setConsent("refused");
+        setVisible(false);
+    };
+
+    return (
+        <div
+            className="cookie-banner"
+            role="dialog"
+            aria-label="Gestion des cookies"
+            aria-live="polite"
+        >
+            <div className="cookie-banner__text">
+                <strong className="cookie-banner__title">Cookies &amp; mesure d'audience</strong>
+                <p>
+                    Nous utilisons Matomo pour mesurer l'audience du site, dans le respect de
+                    votre vie privée. Aucun cookie de mesure n'est déposé sans votre accord.
+                    Détails dans notre{" "}
+                    <Link to="/politique-confidentialite" className="cookie-banner__link">
+                        politique de confidentialité
+                    </Link>
+                    .
+                </p>
+            </div>
+            <div className="cookie-banner__actions">
+                <button
+                    type="button"
+                    className="cookie-banner__btn cookie-banner__btn--refuse"
+                    onClick={refuse}
+                >
+                    Refuser
+                </button>
+                <button
+                    type="button"
+                    className="cookie-banner__btn cookie-banner__btn--accept"
+                    onClick={accept}
+                >
+                    Accepter
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/components/layout/DesktopFooter.tsx
+++ b/frontend/src/components/layout/DesktopFooter.tsx
@@ -1,4 +1,5 @@
 import { Link, NavLink } from "react-router-dom";
+import { openCookieSettings } from "../../lib/consent";
 import type { Menu } from "../../types/api";
 // import { getMenuPath } from "./navigationUtils";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -91,7 +92,7 @@ export function DesktopFooter({ logoUrl }: Props) {
                 </nav>
             </div>
             <div className="footer-bottom">
-                <p>&copy; {new Date().getFullYear()} BCJ37 - Billard Club de Joué-lès-Tours. Tous droits réservés. - <Link to="/cgu" className="footer-link">CGU</Link> - <Link to="/mentions-legales" className="footer-link">Mentions légales</Link> - <Link to="/politique-confidentialite" className="footer-link">Politique de confidentialité</Link></p>
+                <p>&copy; {new Date().getFullYear()} BCJ37 - Billard Club de Joué-lès-Tours. Tous droits réservés. - <Link to="/cgu" className="footer-link">CGU</Link> - <Link to="/mentions-legales" className="footer-link">Mentions légales</Link> - <Link to="/politique-confidentialite" className="footer-link">Politique de confidentialité</Link> - <button type="button" className="footer-link footer-link--button" onClick={openCookieSettings}>Gérer les cookies</button></p>
                 
             </div>
         </div>

--- a/frontend/src/components/layout/MobileFooter.tsx
+++ b/frontend/src/components/layout/MobileFooter.tsx
@@ -1,4 +1,5 @@
 import { Link, NavLink } from "react-router-dom";
+import { openCookieSettings } from "../../lib/consent";
 // import type { Menu } from "../../types/api";
 // import { getMenuPath } from "./navigationUtils";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -70,7 +71,7 @@ export function MobileFooter({ logoUrl }: Props) {
 
             </div>
             <div className="footer-bottom">
-                <p>&copy; {new Date().getFullYear()} BCJ37 - Billard Club de Joué-lès-Tours. Tous droits réservés. - <Link to="/cgu" className="footer-link">CGU</Link> - <Link to="/mentions-legales" className="footer-link">Mentions légales</Link> - <Link to="/politique-confidentialite" className="footer-link">Politique de confidentialité</Link></p>
+                <p>&copy; {new Date().getFullYear()} BCJ37 - Billard Club de Joué-lès-Tours. Tous droits réservés. - <Link to="/cgu" className="footer-link">CGU</Link> - <Link to="/mentions-legales" className="footer-link">Mentions légales</Link> - <Link to="/politique-confidentialite" className="footer-link">Politique de confidentialité</Link> - <button type="button" className="footer-link footer-link--button" onClick={openCookieSettings}>Gérer les cookies</button></p>
             </div>
         </div>
     );

--- a/frontend/src/lib/consent.ts
+++ b/frontend/src/lib/consent.ts
@@ -1,0 +1,59 @@
+/**
+ * Gestion du consentement aux cookies de mesure d'audience (Matomo).
+ *
+ * Le choix du visiteur est memorise dans le localStorage avec sa date. Il est
+ * considere comme expire au-dela de ~6 mois (recommandation CNIL) : le bandeau
+ * est alors re-affiche pour redemander le consentement.
+ */
+export type ConsentStatus = "accepted" | "refused";
+
+const STORAGE_KEY = "bcj_cookie_consent";
+const MAX_AGE_MS = 1000 * 60 * 60 * 24 * 30 * 6; // ~6 mois
+
+/** Evenement emis a chaque changement de choix (accept / refuse). */
+export const CONSENT_CHANGE_EVENT = "bcj:consent-change";
+/** Evenement pour rouvrir le bandeau (lien « Gerer les cookies » du footer). */
+export const OPEN_SETTINGS_EVENT = "bcj:open-cookie-settings";
+
+type StoredConsent = {
+    status: ConsentStatus;
+    date: string;
+};
+
+/**
+ * Retourne le choix de l'utilisateur, ou `null` s'il n'a pas encore choisi
+ * (ou si son choix a expire) — auquel cas le bandeau doit etre affiche.
+ */
+export function getConsent(): ConsentStatus | null {
+    try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        if (!raw) return null;
+
+        const parsed = JSON.parse(raw) as StoredConsent;
+        if (parsed?.status !== "accepted" && parsed?.status !== "refused") {
+            return null;
+        }
+        if (!parsed.date || Date.now() - new Date(parsed.date).getTime() > MAX_AGE_MS) {
+            return null;
+        }
+        return parsed.status;
+    } catch {
+        return null;
+    }
+}
+
+/** Enregistre le choix et notifie l'application. */
+export function setConsent(status: ConsentStatus): void {
+    try {
+        const value: StoredConsent = { status, date: new Date().toISOString() };
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(value));
+    } catch {
+        // localStorage indisponible (navigation privee stricte) : on ignore.
+    }
+    window.dispatchEvent(new CustomEvent(CONSENT_CHANGE_EVENT, { detail: status }));
+}
+
+/** Ouvre (ou rouvre) le bandeau de gestion des cookies. */
+export function openCookieSettings(): void {
+    window.dispatchEvent(new CustomEvent(OPEN_SETTINGS_EVENT));
+}

--- a/frontend/src/lib/matomo.ts
+++ b/frontend/src/lib/matomo.ts
@@ -1,0 +1,69 @@
+/**
+ * Integration Matomo, conditionnee au consentement (opt-in).
+ *
+ * Le script Matomo n'est charge et aucune vue n'est envoyee tant que le
+ * visiteur n'a pas clique « Accepter ». L'URL et l'identifiant du site sont
+ * fournis au build par les variables VITE_MATOMO_URL et VITE_MATOMO_SITE_ID :
+ * si elles sont absentes, la mesure d'audience est simplement desactivee.
+ */
+import { getConsent } from "./consent";
+
+const MATOMO_URL = import.meta.env.VITE_MATOMO_URL as string | undefined;
+const MATOMO_SITE_ID = import.meta.env.VITE_MATOMO_SITE_ID as string | undefined;
+
+declare global {
+    interface Window {
+        _paq?: unknown[][];
+    }
+}
+
+let scriptLoaded = false;
+
+function isConfigured(): boolean {
+    return Boolean(MATOMO_URL && MATOMO_SITE_ID);
+}
+
+function baseUrl(): string {
+    const url = MATOMO_URL as string;
+    return url.endsWith("/") ? url : `${url}/`;
+}
+
+/**
+ * Charge le script Matomo une seule fois (apres consentement).
+ * IP anonymisee cote serveur Matomo recommandee ; ici on active le suivi des
+ * liens et on desactive volontairement les cookies persistants inutiles.
+ */
+export function initMatomo(): void {
+    if (scriptLoaded || !isConfigured() || typeof window === "undefined") return;
+
+    const url = baseUrl();
+    window._paq = window._paq || [];
+    window._paq.push(["enableLinkTracking"]);
+    window._paq.push(["setTrackerUrl", `${url}matomo.php`]);
+    window._paq.push(["setSiteId", MATOMO_SITE_ID as string]);
+
+    const script = document.createElement("script");
+    script.async = true;
+    script.src = `${url}matomo.js`;
+    document.head.appendChild(script);
+
+    scriptLoaded = true;
+}
+
+/**
+ * Envoie une vue de page a Matomo — uniquement si le consentement est donne.
+ * A appeler a chaque changement de route.
+ */
+export function trackPageView(path: string, title?: string): void {
+    if (getConsent() !== "accepted" || !isConfigured() || typeof window === "undefined") {
+        return;
+    }
+
+    initMatomo();
+    window._paq = window._paq || [];
+    if (title) {
+        window._paq.push(["setDocumentTitle", title]);
+    }
+    window._paq.push(["setCustomUrl", path]);
+    window._paq.push(["trackPageView"]);
+}

--- a/frontend/src/router/AppRouter.tsx
+++ b/frontend/src/router/AppRouter.tsx
@@ -16,6 +16,8 @@ import { MainLayout } from "../layouts/MainLayout";
 import { useEffect } from "react";
 import { MentionsPage } from "../pages/MentionsLegales";
 import { PolitiqueConfidentialitePage } from "../pages/PolitiqueConfidentialite";
+import { CookieBanner } from "../components/cookies/CookieBanner";
+import { MatomoTracker } from "../components/analytics/MatomoTracker";
 
 export function AdminRedirect() {
     useEffect(() => {
@@ -28,6 +30,7 @@ export function AdminRedirect() {
 export function AppRouter() {
     return (
         <BrowserRouter>
+            <MatomoTracker />
             <Routes>
                 <Route
                     path="/"
@@ -160,6 +163,7 @@ export function AppRouter() {
                     element={<AdminRedirect />}
                 />
             </Routes>
+            <CookieBanner />
         </BrowserRouter>
     );
 }

--- a/frontend/src/styles/cookieBanner.css
+++ b/frontend/src/styles/cookieBanner.css
@@ -1,0 +1,92 @@
+.cookie-banner {
+    position: fixed;
+    left: 1rem;
+    right: 1rem;
+    bottom: 1rem;
+    z-index: 1000;
+    max-width: 960px;
+    margin: 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem 1.5rem;
+    flex-wrap: wrap;
+    padding: 1rem 1.25rem;
+    background: #ffffff;
+    color: #1f2937;
+    border-radius: 12px;
+    border-top: 4px solid #0e4daa;
+    box-shadow: 0 10px 40px rgba(8, 35, 79, 0.25);
+}
+
+.cookie-banner__text {
+    flex: 1 1 320px;
+}
+
+.cookie-banner__title {
+    display: block;
+    margin-bottom: 0.25rem;
+    color: #0e4daa;
+    font-size: 1.05rem;
+}
+
+.cookie-banner__text p {
+    margin: 0;
+    font-size: 0.9rem;
+    line-height: 1.5;
+}
+
+.cookie-banner__link {
+    color: #0e4daa;
+    text-decoration: underline;
+}
+
+.cookie-banner__actions {
+    display: flex;
+    gap: 0.6rem;
+    flex: 0 0 auto;
+}
+
+.cookie-banner__btn {
+    padding: 0.55rem 1.1rem;
+    border-radius: 8px;
+    border: 1px solid transparent;
+    font-size: 0.9rem;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.cookie-banner__btn--accept {
+    background: #0e4daa;
+    color: #fff;
+}
+
+.cookie-banner__btn--accept:hover {
+    background: #0a2f68;
+}
+
+.cookie-banner__btn--refuse {
+    background: #fff;
+    color: #0e4daa;
+    border-color: #0e4daa;
+}
+
+.cookie-banner__btn--refuse:hover {
+    background: #eef3fb;
+}
+
+.cookie-banner__btn:focus-visible {
+    outline: 2px solid #ff65a3;
+    outline-offset: 2px;
+}
+
+@media (max-width: 640px) {
+    .cookie-banner {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .cookie-banner__actions {
+        justify-content: flex-end;
+    }
+}

--- a/frontend/src/styles/footer.css
+++ b/frontend/src/styles/footer.css
@@ -131,3 +131,14 @@
         display:none;
     }
 }
+/* « Gerer les cookies » : bouton rendu comme un lien texte du pied de page. */
+.footer-link--button {
+    background: none;
+    border: none;
+    padding: 0;
+    margin: 0;
+    font: inherit;
+    color: inherit;
+    text-decoration: underline;
+    cursor: pointer;
+}


### PR DESCRIPTION
Ajoute un **bandeau de consentement RGPD** (Accepter / Refuser) sur le site public et **conditionne la mesure d'audience Matomo au consentement** (opt-in). Matomo n'était pas encore branché sur le nouveau front React : c'est désormais le cas, mais **uniquement après accord** du visiteur.

## Fonctionnement (opt-in, choix : consentement requis)
- Aucun script Matomo, aucune requête tant que le visiteur n'a pas cliqué **« Accepter »**.
- **« Refuser »** → rien n'est chargé.
- Choix mémorisé (localStorage), **ré-expiré après ~6 mois** (recommandation CNIL) → le bandeau réapparaît.
- Lien **« Gérer les cookies »** ajouté au pied de page pour revenir sur son choix.
- Si `VITE_MATOMO_URL` / `VITE_MATOMO_SITE_ID` ne sont pas renseignés → mesure d'audience simplement **désactivée** (le bandeau reste inoffensif).

## Fichiers
- `lib/consent.ts` — logique de consentement (stockage, expiration, événements).
- `lib/matomo.ts` — init Matomo + envoi des vues, **gardé par le consentement**.
- `components/cookies/CookieBanner.tsx` + `styles/cookieBanner.css` — le bandeau (charte BCJ, responsive, accessible).
- `components/analytics/MatomoTracker.tsx` — une vue par changement de route (SPA), si consentement.
- `router/AppRouter.tsx` — intègre le tracker + le bandeau.
- `layout/DesktopFooter.tsx` + `MobileFooter.tsx` + `footer.css` — lien « Gérer les cookies ».
- `frontend/.env*` (local, non versionné) — nouvelles clés `VITE_MATOMO_URL` / `VITE_MATOMO_SITE_ID`.

## Vérifications
- ✅ `npm run lint` : 0 erreur.
- ✅ `npm run build` : OK.

## À faire côté config (avant build de prod)
Renseigner dans **`frontend/.env.production`** (local, utilisé au build) :
- `VITE_MATOMO_URL=` l'URL de ton instance Matomo (ex. `https://analytics.bcj37.fr/matomo/`)
- `VITE_MATOMO_SITE_ID=` l'identifiant du site bcj37 dans Matomo

Puis rebuild (via `deploy.ps1`). En local (`frontend/.env`) les clés sont vides → Matomo désactivé en dev.

> Pense aussi à mentionner Matomo + le mécanisme de consentement dans la **Politique de confidentialité** (contenu légal à valider de ton côté).