### PR TITLE
fix : la page club n'affiche que les articles du club (hors disciplines)

### DIFF
--- a/app/Http/Controllers/Api/PostController.php
+++ b/app/Http/Controllers/Api/PostController.php
@@ -24,9 +24,10 @@ use Illuminate\Pagination\LengthAwarePaginator;
 class PostController extends Controller
 {
     /**
-     * Liste des articles
+     * Articles du club
      *
-     * Retourne la liste paginée des articles, triés du plus récent au plus ancien.
+     * Retourne la liste paginée des articles du club (hors disciplines), triés du
+     * plus récent au plus ancien. Alimente la page « Vie du club ».
      *
      * @group Articles
      *
@@ -54,8 +55,10 @@ class PostController extends Controller
      */
     public function index(): JsonResponse
     {
+        // Page « Vie du club » : uniquement les articles du club (hors disciplines).
         $posts = Post::query()
             ->published()
+            ->club()
             ->orderByDesc('created_at')
             ->paginate($this->getPerPage());
 
@@ -369,8 +372,10 @@ class PostController extends Controller
 
         $selectedPeriod = $periods[$period];
 
+        // Archives de la page club : uniquement les articles du club (hors disciplines).
         $posts = Post::query()
             ->published()
+            ->club()
             ->when($selectedPeriod['operator'] === '>=', function ($query) use ($selectedPeriod) {
                 $query->where('year', '>=', $selectedPeriod['start_year']);
             })

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -72,6 +72,19 @@ class Post extends Model
             });
     }
 
+    /**
+     * Articles « du club » : ceux qui ne sont rattaches a aucune discipline
+     * (blackball=1, carambole=2, snooker=3, americain=4). Le club correspond a
+     * une discipline nulle/0 ou hors de cette liste (cf. DisciplineMapper).
+     */
+    public function scopeClub($query)
+    {
+        return $query->where(function ($q) {
+            $q->whereNull('discipline')
+                ->orWhereNotIn('discipline', [1, 2, 3, 4]);
+        });
+    }
+
     public function getRouteKeyName(): string
     {
         return 'slug';

--- a/tests/Feature/ClubPostsFilterTest.php
+++ b/tests/Feature/ClubPostsFilterTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Post;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * La page « Vie du club » ne doit lister que les articles du club, c'est-a-dire
+ * ceux qui ne sont rattaches a aucune discipline (blackball, carambole, snooker,
+ * americain). Couvre le listing par defaut (/posts) et par periode.
+ */
+class ClubPostsFilterTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_club_listing_returns_only_non_discipline_posts(): void
+    {
+        Post::factory()->create(['title' => 'Club (null)', 'discipline' => null]);
+        Post::factory()->create(['title' => 'Club (0)', 'discipline' => 0]);
+        Post::factory()->create(['title' => 'Blackball', 'discipline' => 1]);
+        Post::factory()->create(['title' => 'Carambole', 'discipline' => 2]);
+
+        $titles = collect($this->getJson('/api/v1/posts')->assertOk()->json('data'))
+            ->pluck('title');
+
+        $this->assertContains('Club (null)', $titles);
+        $this->assertContains('Club (0)', $titles);
+        $this->assertNotContains('Blackball', $titles);
+        $this->assertNotContains('Carambole', $titles);
+        $this->assertCount(2, $titles);
+    }
+
+    public function test_club_period_listing_excludes_discipline_posts(): void
+    {
+        $year = (int) now()->year;
+        Post::factory()->create(['title' => 'Club recent', 'discipline' => null, 'year' => $year]);
+        Post::factory()->create(['title' => 'Snooker recent', 'discipline' => 3, 'year' => $year]);
+
+        $currentDecade = (int) floor($year / 10) * 10;
+        $titles = collect(
+            $this->getJson("/api/v1/posts/period/depuis_{$currentDecade}")->assertOk()->json('data')
+        )->pluck('title');
+
+        $this->assertContains('Club recent', $titles);
+        $this->assertNotContains('Snooker recent', $titles);
+    }
+}

--- a/tests/Feature/PostPublicationTest.php
+++ b/tests/Feature/PostPublicationTest.php
@@ -18,9 +18,11 @@ class PostPublicationTest extends TestCase
 
     public function test_public_list_excludes_drafts_and_scheduled_posts(): void
     {
-        Post::factory()->create(['title' => 'Publie']);
-        Post::factory()->draft()->create(['title' => 'Brouillon']);
-        Post::factory()->scheduled()->create(['title' => 'Programme']);
+        // discipline null : ce sont des articles « club », donc listes par /posts
+        // (qui ne renvoie que les articles du club, cf. ClubPostsFilterTest).
+        Post::factory()->create(['title' => 'Publie', 'discipline' => null]);
+        Post::factory()->draft()->create(['title' => 'Brouillon', 'discipline' => null]);
+        Post::factory()->scheduled()->create(['title' => 'Programme', 'discipline' => null]);
 
         $titles = collect(
             $this->getJson('/api/v1/posts')->assertOk()->json('data')


### PR DESCRIPTION
## Problème
La page **« Vie du club »** affichait **tous** les articles, alors qu'elle ne doit lister que les articles **du club** — c'est-à-dire ceux qui ne sont rattachés à **aucune discipline** (blackball, carambole, snooker, américain).

## Cause
Les deux endpoints qui alimentent la page club (`GET /api/v1/posts` et `GET /api/v1/posts/period/{period}`) ne filtraient pas la discipline. Le filtrage ne pouvait pas être fait côté front (ça aurait cassé la pagination) → correction **côté serveur**.

## Correctif
- Nouveau scope **`Post::club()`** : `discipline` nulle/0 ou hors `[1,2,3,4]` (cf. `DisciplineMapper` : club = pas de discipline).
- Appliqué à `index()` (liste) et `getPostByPeriod()` (archives) du `PostController`.

## Vérifications
- ✅ Nouveau test `ClubPostsFilterTest` : `/posts` et `/posts/period` ne renvoient que les articles club (discipline null/0), pas blackball/carambole/snooker.
- ✅ `PostPublicationTest` ajusté (ses articles sont désormais « club » pour rester listés par `/posts`).
- ✅ Suite complète : **197 tests / 3064 assertions** au vert · `pint` conforme.

## Note
`GET /api/v1/posts` est désormais **spécifique à la page club** (son unique conscommateur). Sa documentation a été mise à jour en conséquence.