### PR TITLE
Admin : réorganiser le menu OpenAdmin (plus lisible)

### DIFF
--- a/database/migrations/2026_07_18_000001_reorganize_admin_menu_sections.php
+++ b/database/migrations/2026_07_18_000001_reorganize_admin_menu_sections.php
@@ -1,0 +1,108 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Reorganisation du menu OpenAdmin pour le rendre plus lisible :
+ *  - « Contenu du site » ne contient plus que du contenu (+ Documents rapatrie) ;
+ *  - les licencies deviennent une SECTION dediee (au lieu d'etre noyes dans
+ *    « Contenu du site ») ;
+ *  - la configuration est regroupee dans une section « Parametres »
+ *    (Parametres du site + Menus du site).
+ *
+ * Toutes les operations sont reperees par URI (stable d'une base a l'autre) et
+ * idempotentes : la migration peut etre rejouee sans dupliquer ni casser.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $now = now();
+
+        $topSection = function (string $title) {
+            return DB::table('admin_menu')
+                ->where('parent_id', 0)
+                ->where('title', $title)
+                ->whereRaw("(uri IS NULL OR uri = '')")
+                ->first();
+        };
+
+        $ensureSection = function (string $title, string $icon, int $order) use ($topSection, $now) {
+            $existing = $topSection($title);
+            if ($existing) {
+                // Met a jour l'ordre / l'icone meme si la section existe deja
+                // (idempotence : la migration peut etre rejouee proprement).
+                DB::table('admin_menu')->where('id', $existing->id)->update([
+                    'order' => $order,
+                    'icon' => $icon,
+                    'updated_at' => $now,
+                ]);
+
+                return (int) $existing->id;
+            }
+
+            return (int) DB::table('admin_menu')->insertGetId([
+                'parent_id' => 0,
+                'order' => $order,
+                'title' => $title,
+                'icon' => $icon,
+                'uri' => '',
+                'permission' => null,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]);
+        };
+
+        $move = function (string $uri, int $parentId, int $order, ?string $newTitle = null) use ($now) {
+            $data = ['parent_id' => $parentId, 'order' => $order, 'updated_at' => $now];
+            if ($newTitle !== null) {
+                $data['title'] = $newTitle;
+            }
+            DB::table('admin_menu')->where('uri', $uri)->update($data);
+        };
+
+        // 1) Section « Licencies » + rattachement des entrees licencies.
+        $licencies = $ensureSection('Licenciés', 'icon-users', 5);
+        $move('licencies', $licencies, 1, 'Liste des licenciés');
+        $move('license-import/batches', $licencies, 2, 'Import des licenciés');
+        $move('cuescore-mappings', $licencies, 3, 'Correspondances CueScore');
+
+        // 2) Documents rapatrie dans « Contenu du site ».
+        if ($contenu = $topSection('Contenu du site')) {
+            $move('documents', (int) $contenu->id, 50);
+        }
+
+        // 3) Section « Parametres » : Parametres du site + Menus du site.
+        $parametres = $ensureSection('Paramètres', 'icon-cog', 50);
+        $move('site-settings', $parametres, 1, 'Paramètres du site');
+        $move('menus', $parametres, 2, 'Menus du site');
+    }
+
+    public function down(): void
+    {
+        $now = now();
+
+        $topByTitle = fn (string $t) => DB::table('admin_menu')
+            ->where('parent_id', 0)->where('title', $t)
+            ->whereRaw("(uri IS NULL OR uri = '')")->first();
+
+        // Remettre les entrees deplacees dans « Contenu du site » / au niveau 1.
+        if ($contenu = $topByTitle('Contenu du site')) {
+            foreach (['licencies', 'license-import/batches', 'cuescore-mappings', 'menus'] as $uri) {
+                DB::table('admin_menu')->where('uri', $uri)
+                    ->update(['parent_id' => (int) $contenu->id, 'updated_at' => $now]);
+            }
+        }
+        DB::table('admin_menu')->whereIn('uri', ['documents', 'site-settings'])
+            ->update(['parent_id' => 0, 'updated_at' => $now]);
+
+        // Supprimer les sections creees si elles sont vides.
+        foreach (['Licenciés', 'Paramètres'] as $title) {
+            $section = $topByTitle($title);
+            if ($section && DB::table('admin_menu')->where('parent_id', $section->id)->doesntExist()) {
+                DB::table('admin_menu')->where('id', $section->id)->delete();
+            }
+        }
+    }
+};


### PR DESCRIPTION
Réorganise le menu d'administration pour le rendre plus clair pour les bénévoles. Le principal problème : **« Contenu du site » était un fourre-tout** mêlant contenu, licenciés et configuration.

## Avant → Après

**Avant** — « Contenu du site » contenait : Actualités, Partenaires, Informations accueil, Message d'accueil **+ Licenciés, Import, Licenciés↔CueScore + Menus du site**. Les licenciés étaient noyés, et « Documents » / « Paramètres du site » traînaient au niveau principal.

**Après** :
| Section | Contenu |
|---|---|
| **Contenu du site** | Message d'accueil · Actualités · Partenaires · Informations accueil · **Documents** *(contenu uniquement)* |
| **Licenciés** *(nouvelle section)* | Liste des licenciés · Import des licenciés · Correspondances CueScore |
| Blackball / Carambole / Snooker / Américain | *(inchangées, au niveau principal)* |
| Contacts | — |
| **Paramètres** *(section)* | Paramètres du site · Menus du site |
| Administration technique / Outils développeur | *(inchangées)* |

**Gains** : les licenciés ont enfin une section propre et visible, « Contenu » ne contient que du contenu, la config est regroupée, et « Documents » rejoint le contenu.

## Technique
- Migration **repérée par URI** (stable d'une base à l'autre : local, test, prod) et **idempotente** (rejouable sans doublon), avec un `down()` de réversion.
- Vérifiée : arborescence conforme, ordre du menu propre, `/admin` rendu en 200.

## Vérifications
- ✅ Migration exécutée en local, arborescence conforme à la cible.
- ✅ Rendu `/admin` testé (200).
- ✅ Suite complète : **197 tests / 3064 assertions**.

## Déploiement
Après merge, `deploy.ps1` applique la migration (le menu se réorganise). Un `Ctrl+F5` au besoin.