### PR TITLE
perf(front): optimiser le chargement des images

### DIFF
--- a/frontend/src/components/club/ClubPostCard.tsx
+++ b/frontend/src/components/club/ClubPostCard.tsx
@@ -63,7 +63,6 @@ export default function ClubPostCard({
             src={imageSrc}
             alt={title}
             width="279"
-            height="auto"
             className="club-post-card__image"
             loading={priority ? "eager" : "lazy"}
             fetchPriority={priority ? "high" : "auto"}

--- a/frontend/src/components/layout/DesktopFooter.tsx
+++ b/frontend/src/components/layout/DesktopFooter.tsx
@@ -29,6 +29,10 @@ export function DesktopFooter({ logoUrl }: Props) {
                                 src={logoUrl}
                                 alt="BCJ37 - Billard Club de Joué-lès-Tours"
                                 className="site-logo__image"
+                                width={706}
+                                height={349}
+                                loading="lazy"
+                                decoding="async"
                             />
                         ) : (
                             <span>BCJ37</span>

--- a/frontend/src/components/layout/DesktopNavigation.tsx
+++ b/frontend/src/components/layout/DesktopNavigation.tsx
@@ -28,6 +28,9 @@ export function DesktopNavigation({ menus, logoUrl }: Props) {
                             src={logoUrl}
                             alt="BCJ37 - Billard Club de Joué-lès-Tours"
                             className="site-logo-desktop site-logo__image"
+                            width={706}
+                            height={349}
+                            decoding="async"
                         />
                     ) : (
                         <span>BCJ37</span>
@@ -47,6 +50,7 @@ export function DesktopNavigation({ menus, logoUrl }: Props) {
                                     src={menu.image_url}
                                     alt={menu.name}
                                     className="menu-image"
+                                    decoding="async"
                                 />
                             ) : (
                                 menu.name

--- a/frontend/src/components/layout/MobileFooter.tsx
+++ b/frontend/src/components/layout/MobileFooter.tsx
@@ -28,6 +28,10 @@ export function MobileFooter({ logoUrl }: Props) {
                                 src={logoUrl}
                                 alt="BCJ37 - Billard Club de Joué-lès-Tours"
                                 className="site-logo__image"
+                                width={706}
+                                height={349}
+                                loading="lazy"
+                                decoding="async"
                             />
                         ) : (
                             <span>BCJ37</span>

--- a/frontend/src/components/layout/MobileNavigation.tsx
+++ b/frontend/src/components/layout/MobileNavigation.tsx
@@ -102,6 +102,9 @@ export function MobileNavigation({ logoUrl }: Props) {
                                 src={logoUrl}
                                 alt="BCJ37 - Billard Club de Joué-lès-Tours"
                                 className="site-logo__image"
+                                width={706}
+                                height={349}
+                                decoding="async"
                             />
                         ) : (
                             <span>BCJ37</span>

--- a/frontend/src/components/partners/PartnersCarousel.tsx
+++ b/frontend/src/components/partners/PartnersCarousel.tsx
@@ -47,6 +47,7 @@ function PartnerItem({ partner, duplicated = false }: PartnerItemProps) {
             src={partner.logo_url as string}
             alt={duplicated ? "" : label}
             loading="lazy"
+            decoding="async"
             onError={() => setImageFailed(true)}
         />
     ) : (

--- a/frontend/src/pages/ErrorPage.tsx
+++ b/frontend/src/pages/ErrorPage.tsx
@@ -22,6 +22,7 @@ export function ErrorPage({
                     alt=""
                     className="error-page__image"
                     aria-hidden="true"
+                    decoding="async"
                 />
 
                 <p className="error-page__code">

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -50,6 +50,10 @@ export function HomePage() {
                     src={home.site_settings.banniere_url}
                     alt="Bienvenue au BCJ37"
                     className="hero-banner"
+                    width={3222}
+                    height={964}
+                    fetchPriority="high"
+                    decoding="async"
                 />
             )}
         </div>
@@ -102,6 +106,8 @@ export function HomePage() {
                                         src={home.featured_post.image_url}
                                         alt={home.featured_post.title ?? home.featured_post.titre}
                                         style={{ maxWidth: "100%" }}
+                                        loading="lazy"
+                                        decoding="async"
                                     />
                                 ) : null}
 

--- a/frontend/src/pages/NotFoundPage.tsx
+++ b/frontend/src/pages/NotFoundPage.tsx
@@ -21,6 +21,7 @@ export function NotFoundPage() {
                     alt=""
                     className="error-page__image"
                     aria-hidden="true"
+                    decoding="async"
                 />
 
                 <p className="error-page__code">404</p>

--- a/frontend/src/pages/PostPage.tsx
+++ b/frontend/src/pages/PostPage.tsx
@@ -186,6 +186,8 @@ export function PostPage() {
                                 src={post.image_url}
                                 alt={postTitle}
                                 style={{ maxWidth: "800px" }}
+                                fetchPriority="high"
+                                decoding="async"
                             />
                         ) : null}
                     </div>


### PR DESCRIPTION
## Contexte
Audit complet des images du site : certaines mettaient plus de temps a charger que d'autres. Cette PR traite le **cote affichage** (markup). Le cote **donnees** (images legacy lourdes, compression bannieres/logos) est detaille plus bas comme suite recommandee.

## Changements (markup)
- **Banniere d'accueil** (image LCP, la plus lourde a l'ecran) : `fetchpriority="high"`, `decoding="async"` et dimensions intrinseques (3222×964) pour reserver l'espace et eviter le decalage de mise en page (CLS).
- **Image principale d'un article** : chargement prioritaire (elle est en haut de la page).
- **Article a la une (accueil)** et **logos partenaires** : `loading="lazy"` + `decoding="async"` (sous la ligne de flottaison).
- **Logos** (nav + pied de page) : dimensions + `decoding="async"` ; les logos de **pied de page** passent en `lazy`.
- **Vignettes d'articles** : suppression de l'attribut `height="auto"` invalide (annulait l'effet anti-CLS du `width`).

Les listes utilisent deja la miniature WebP (`image_thumb_url`) et le lazy-loading — inchange.

## Verification
- ESLint : OK
- `tsc --noEmit` : OK

## Suite recommandee (cote donnees — non incluse)
Le vrai poids vient de deux sources cote serveur :
1. **Images d'articles "legacy"** dans `storage/app/public/files/*.png` de **1 a 4 Mo** (anciennes, jamais reconverties). Sans miniature WebP associee, elles retombent sur l'original de plusieurs Mo, meme dans les listes.
2. **Banniere / logo** enregistres **bruts** (le formulaire d'admin ne les compresse pas, contrairement au menu, aux articles et aux partenaires).

Proposition : une commande artisan idempotente (`images:optimize`, avec `--dry-run`) qui recompresse/convertit ces images et regenere les miniatures manquantes, + ajout de la compression a l'upload banniere/logo. A faire dans une PR dediee.