### PR TITLE
feat(admin): compresser le logo et la banniere a l'upload (WebP)

### DIFF
--- a/app/Admin/Controllers/SiteSettingController.php
+++ b/app/Admin/Controllers/SiteSettingController.php
@@ -3,6 +3,9 @@
 namespace App\Admin\Controllers;
 
 use App\Models\SiteSetting;
+use App\Support\ImageOptimizer;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 use OpenAdmin\Admin\Admin;
 use OpenAdmin\Admin\Controllers\AdminController;
 use OpenAdmin\Admin\Form;
@@ -83,19 +86,19 @@ class SiteSettingController extends AdminController
         $form = new Form(new SiteSetting);
 
         // --- Identite visuelle ---------------------------------------------
+        // Le logo et la banniere sont recompresses en WebP a l'enregistrement
+        // (voir saving() plus bas) : les fichiers uploades ne sont jamais
+        // stockes bruts, pour ne pas alourdir le chargement du site.
         $form->fieldset(__('Identité visuelle'), function (Form $form) {
-            $form->image('logo', 'Logo du club')
-                ->disk('public')
-                ->move('img')
-                ->uniqueName()
-                ->help('Logo affiché sur le site. Ratio recommandé : 706 × 349 px.');
+            $form->file('logo', 'Logo du club')
+                ->removable()
+                ->rules('nullable|image|max:8192')
+                ->help('Logo affiché sur le site. Ratio recommandé : 706 × 349 px. Converti automatiquement en WebP.');
 
-            $form->image('banniere', 'Bannière d\'accueil')
-                ->disk('public')
-                ->move('img')
-                ->uniqueName()
-                ->rules('image|max:8192')
-                ->help('Grande image en haut de la page d\'accueil. Ratio recommandé : 3222 × 964 px.');
+            $form->file('banniere', 'Bannière d\'accueil')
+                ->removable()
+                ->rules('nullable|image|max:8192')
+                ->help('Grande image en haut de la page d\'accueil. Ratio recommandé : 3222 × 964 px. Convertie automatiquement en WebP.');
         });
 
         // --- Coordonnees ----------------------------------------------------
@@ -116,6 +119,34 @@ class SiteSettingController extends AdminController
                 ->help('Adresse complète de la page (https://…).');
             $form->text('facebook_page_id', 'Identifiant de la page Facebook')
                 ->help('Facultatif — utilisé pour l\'intégration Facebook.');
+        });
+
+        // OpenAdmin ne doit pas enregistrer le fichier brut : on gere logo et
+        // banniere nous-memes dans saving() (conversion WebP + compression).
+        $form->ignore(['logo', 'banniere']);
+
+        $form->saving(function (Form $form) {
+            // Reglages alignes sur la commande images:optimize (coherence).
+            $process = function (string $column, int $maxWidth, int $quality) use ($form) {
+                $file = request()->file($column);
+                if (! $file) {
+                    return;
+                }
+
+                $path = 'img/'.Str::uuid().'.webp';
+                Storage::disk('public')->put($path, ImageOptimizer::toWebp($file, $maxWidth, $quality));
+
+                // Supprime l'ancien fichier lors d'une mise a jour.
+                $old = $form->model()->getOriginal($column);
+                if ($old) {
+                    Storage::disk('public')->delete($old);
+                }
+
+                $form->model()->{$column} = $path;
+            };
+
+            $process('logo', 800, 85);
+            $process('banniere', 2000, 82);
         });
 
         // Aide a la saisie du telephone (mise en forme automatique).

--- a/app/Support/ImageOptimizer.php
+++ b/app/Support/ImageOptimizer.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Http\UploadedFile;
+use Intervention\Image\Drivers\Gd\Driver as GdDriver;
+use Intervention\Image\ImageManager;
+
+/**
+ * Encodage WebP mutualise pour l'upload d'images (banniere, logo…).
+ *
+ * Centralise la meme logique que le pipeline existant (largeur maximale +
+ * qualite) afin qu'elle soit testable et coherente d'un point d'entree a
+ * l'autre.
+ */
+class ImageOptimizer
+{
+    /**
+     * Retourne le contenu WebP d'une image, redimensionnee si elle depasse la
+     * largeur maximale (les proportions sont conservees).
+     *
+     * @param  UploadedFile|string  $source  Fichier uploade ou chemin absolu.
+     */
+    public static function toWebp(UploadedFile|string $source, int $maxWidth, int $quality): string
+    {
+        $path = $source instanceof UploadedFile ? $source->getRealPath() : $source;
+
+        $image = (new ImageManager(new GdDriver))->read($path);
+
+        if ($image->width() > $maxWidth) {
+            $image = $image->scale(width: $maxWidth);
+        }
+
+        return (string) $image->toWebp(quality: $quality);
+    }
+}

--- a/tests/Unit/ImageOptimizerTest.php
+++ b/tests/Unit/ImageOptimizerTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Support\ImageOptimizer;
+use Illuminate\Http\UploadedFile;
+use Intervention\Image\Drivers\Gd\Driver as GdDriver;
+use Intervention\Image\ImageManager;
+use PHPUnit\Framework\TestCase;
+
+class ImageOptimizerTest extends TestCase
+{
+    private function isWebp(string $data): bool
+    {
+        // En-tete RIFF....WEBP.
+        return strlen($data) > 12
+            && substr($data, 0, 4) === 'RIFF'
+            && substr($data, 8, 4) === 'WEBP';
+    }
+
+    public function test_redimensionne_les_images_trop_larges_et_encode_en_webp(): void
+    {
+        $file = UploadedFile::fake()->image('grande.jpg', 2000, 1000);
+
+        $webp = ImageOptimizer::toWebp($file, 800, 82);
+
+        $this->assertTrue($this->isWebp($webp), 'la sortie doit etre un WebP valide');
+
+        $image = (new ImageManager(new GdDriver))->read($webp);
+        $this->assertSame(800, $image->width(), 'largeur ramenee au maximum');
+        $this->assertSame(400, $image->height(), 'proportions conservees');
+    }
+
+    public function test_nagrandit_pas_les_images_plus_petites_que_le_maximum(): void
+    {
+        $file = UploadedFile::fake()->image('petite.jpg', 300, 200);
+
+        $webp = ImageOptimizer::toWebp($file, 800, 82);
+
+        $image = (new ImageManager(new GdDriver))->read($webp);
+        $this->assertSame(300, $image->width(), 'aucune mise a l\'echelle vers le haut');
+        $this->assertSame(200, $image->height());
+    }
+
+    public function test_accepte_un_chemin_de_fichier(): void
+    {
+        $file = UploadedFile::fake()->image('depuis-chemin.jpg', 1200, 600);
+
+        $webp = ImageOptimizer::toWebp($file->getRealPath(), 800, 82);
+
+        $this->assertTrue($this->isWebp($webp));
+        $image = (new ImageManager(new GdDriver))->read($webp);
+        $this->assertSame(800, $image->width());
+    }
+}


### PR DESCRIPTION
## Contexte
Suite de l'optimisation des images. La commande `images:optimize` (PR #98) nettoie l'existant ; cette PR **empeche de reintroduire le probleme** : jusqu'ici, le formulaire des parametres du site enregistrait le **logo et la banniere bruts** (parfois plusieurs Mo), alors que le menu, les articles et les partenaires sont deja compresses a l'upload.

## Changements
- **Nouveau helper `App\Support\ImageOptimizer::toWebp()`** : centralise la conversion WebP (largeur maximale + qualite, proportions conservees). Mutualisable et **teste unitairement**.
- **`SiteSettingController`** : le logo (max 800 px, q85) et la banniere (max 2000 px, q82) sont convertis en WebP dans `saving()`. L'ancien fichier est supprime lors d'une mise a jour. Champs `image()` remplaces par `file()` + `ignore()` + `saving()`, comme le contrôleur des partenaires.
- Reglages **alignes sur la commande `images:optimize`** (coherence bout en bout).

## Tests
- 3 tests unitaires du helper (redimensionnement, pas d'agrandissement, entree par chemin, sortie WebP valide).
- Formulaire d'edition : rendu 200 verifie.
- Suite complete : **203 passed** (3085 assertions).

## Effet
Un logo/banniere de plusieurs Mo televerse via l'admin est desormais stocke en WebP compresse (typiquement quelques dizaines de Ko), sans action manuelle.