### PR TITLE
perf(front): decoupage du JS par route, Leaflet differe, cache navigateur

### DIFF
--- a/frontend/public/.htaccess
+++ b/frontend/public/.htaccess
@@ -1,0 +1,46 @@
+# Configuration Apache du site public (SPA React).
+# Ce fichier est copie tel quel dans dist/ au build (dossier public/ de Vite)
+# et doit se trouver a la racine du domaine servant le front.
+
+# --- Compression des ressources texte -------------------------------------
+<IfModule mod_deflate.c>
+    AddOutputFilterByType DEFLATE text/html text/plain text/css text/xml
+    AddOutputFilterByType DEFLATE application/javascript application/json
+    AddOutputFilterByType DEFLATE image/svg+xml
+</IfModule>
+
+# --- Cache navigateur ------------------------------------------------------
+<IfModule mod_headers.c>
+    # Les assets buildes portent un hash dans leur nom (ex: index-Kk2wqTxI.js) :
+    # leur contenu ne change jamais sans changer de nom -> cache long et immuable.
+    <FilesMatch "\.(js|css|woff2?|ttf|otf|eot|svg|png|jpe?g|webp|avif|gif|ico)$">
+        Header set Cache-Control "public, max-age=31536000, immutable"
+    </FilesMatch>
+
+    # index.html ne porte pas de hash : il doit etre revalide a chaque visite
+    # pour recuperer immediatement chaque nouveau deploiement.
+    <FilesMatch "^index\.html$">
+        Header set Cache-Control "no-cache, must-revalidate"
+    </FilesMatch>
+</IfModule>
+
+# robots.txt et sitemap.xml changent regulierement : pas de cache long.
+<IfModule mod_headers.c>
+    <FilesMatch "\.(txt|xml)$">
+        Header set Cache-Control "public, max-age=3600"
+    </FilesMatch>
+</IfModule>
+
+# --- Routage SPA -----------------------------------------------------------
+# Toute URL qui ne correspond pas a un fichier/dossier existant est renvoyee
+# vers index.html : le routage est gere cote client par React Router.
+<IfModule mod_rewrite.c>
+    RewriteEngine On
+    RewriteBase /
+
+    RewriteCond %{REQUEST_FILENAME} -f [OR]
+    RewriteCond %{REQUEST_FILENAME} -d
+    RewriteRule ^ - [L]
+
+    RewriteRule ^ index.html [L]
+</IfModule>

--- a/frontend/src/components/map/ClubMap.tsx
+++ b/frontend/src/components/map/ClubMap.tsx
@@ -1,5 +1,10 @@
 import { MapContainer, TileLayer, Marker, Popup, ScaleControl } from "react-leaflet";
 import L from "leaflet";
+import "leaflet/dist/leaflet.css";
+// Icones servies localement (bundlees par Vite) plutot que depuis unpkg.com :
+// on evite deux requetes vers un domaine externe.
+import markerIconUrl from "leaflet/dist/images/marker-icon.png";
+import markerShadowUrl from "leaflet/dist/images/marker-shadow.png";
 
 const position: [number, number] = [
     47.341811344805635,
@@ -7,8 +12,8 @@ const position: [number, number] = [
 ];
 
 const markerIcon = new L.Icon({
-    iconUrl: "https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png",
-    shadowUrl: "https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png",
+    iconUrl: markerIconUrl,
+    shadowUrl: markerShadowUrl,
     iconSize: [25, 41],
     iconAnchor: [12, 41],
 });

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,7 +1,6 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './styles/index.css'
-import "leaflet/dist/leaflet.css";
 import App from './App.tsx'
 import { HelmetProvider } from 'react-helmet-async';
 

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,8 +1,11 @@
-import { useEffect, useState } from "react";
+import { lazy, Suspense, useEffect, useState } from "react";
 import { getHome } from "../api/publicApi";
 import { Link } from "react-router-dom";
 import type { HomeData } from "../types/api";
-import { ClubMap } from "../components/map/ClubMap";
+
+// La carte (Leaflet, dependance lourde) est sous la ligne de flottaison :
+// on la charge a la demande pour ne pas peser sur le rendu initial de l'accueil.
+const ClubMap = lazy(() => import("../components/map/ClubMap").then((m) => ({ default: m.ClubMap })));
 import { InfoBanner } from "../components/info/InfoBanner";
 import { ArticleCard } from "../components/ui/Card";
 import { ArticleTitle } from "../components/ui/Title";
@@ -76,7 +79,9 @@ export function HomePage() {
             <section className="maps" aria-labelledby="maps-title">
                 <ArticleTitle id="maps-title">Nous trouver</ArticleTitle>
                 <ArticleCard className="home-section home-map">
-                    <ClubMap />
+                    <Suspense fallback={<div className="leaflet-map" aria-busy="true" />}>
+                        <ClubMap />
+                    </Suspense>
                 </ArticleCard>
             </section>
 

--- a/frontend/src/router/AppRouter.tsx
+++ b/frontend/src/router/AppRouter.tsx
@@ -1,23 +1,27 @@
+import { lazy, Suspense, useEffect } from "react";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
-import { HomePage } from "../pages/HomePage";
-import { DisciplinePage } from "../pages/DisciplinePage";
-import { NotFoundPage } from "../pages/NotFoundPage";
-import { PostPage } from "../pages/PostPage";
-import { ClubPostsPage } from "../pages/ClubPostsPage";
-import { CalendarPage } from "../pages/CalendarPage";
-import { ContactPage } from "../pages/ContactPage";
-import { ErrorPage } from "../pages/ErrorPage";
-import { CGUPage } from "../pages/CGUPage";
-import { DisciplineDocumentsPage } from "../components/discipline/DisciplineDocumentsPage";
-import { DisciplineRankingsPage } from "../components/discipline/DisciplineRankingsPage";
-import { DisciplineCalendarPage } from "../components/discipline/DisciplineCalendarPage";
-import { DisciplinePostsPage } from "../components/discipline/DisciplinePostsPage";
 import { MainLayout } from "../layouts/MainLayout";
-import { useEffect } from "react";
-import { MentionsPage } from "../pages/MentionsLegales";
-import { PolitiqueConfidentialitePage } from "../pages/PolitiqueConfidentialite";
 import { CookieBanner } from "../components/cookies/CookieBanner";
 import { MatomoTracker } from "../components/analytics/MatomoTracker";
+
+// Chargement differe des pages : chaque page devient un fichier JS separe,
+// telecharge uniquement lorsque l'utilisateur visite la route correspondante.
+// Le bundle initial (page d'accueil) s'en trouve nettement allege.
+const HomePage = lazy(() => import("../pages/HomePage").then((m) => ({ default: m.HomePage })));
+const DisciplinePage = lazy(() => import("../pages/DisciplinePage").then((m) => ({ default: m.DisciplinePage })));
+const NotFoundPage = lazy(() => import("../pages/NotFoundPage").then((m) => ({ default: m.NotFoundPage })));
+const PostPage = lazy(() => import("../pages/PostPage").then((m) => ({ default: m.PostPage })));
+const ClubPostsPage = lazy(() => import("../pages/ClubPostsPage").then((m) => ({ default: m.ClubPostsPage })));
+const CalendarPage = lazy(() => import("../pages/CalendarPage").then((m) => ({ default: m.CalendarPage })));
+const ContactPage = lazy(() => import("../pages/ContactPage").then((m) => ({ default: m.ContactPage })));
+const ErrorPage = lazy(() => import("../pages/ErrorPage").then((m) => ({ default: m.ErrorPage })));
+const CGUPage = lazy(() => import("../pages/CGUPage").then((m) => ({ default: m.CGUPage })));
+const MentionsPage = lazy(() => import("../pages/MentionsLegales").then((m) => ({ default: m.MentionsPage })));
+const PolitiqueConfidentialitePage = lazy(() => import("../pages/PolitiqueConfidentialite").then((m) => ({ default: m.PolitiqueConfidentialitePage })));
+const DisciplineDocumentsPage = lazy(() => import("../components/discipline/DisciplineDocumentsPage").then((m) => ({ default: m.DisciplineDocumentsPage })));
+const DisciplineRankingsPage = lazy(() => import("../components/discipline/DisciplineRankingsPage").then((m) => ({ default: m.DisciplineRankingsPage })));
+const DisciplineCalendarPage = lazy(() => import("../components/discipline/DisciplineCalendarPage").then((m) => ({ default: m.DisciplineCalendarPage })));
+const DisciplinePostsPage = lazy(() => import("../components/discipline/DisciplinePostsPage").then((m) => ({ default: m.DisciplinePostsPage })));
 
 export function AdminRedirect() {
     useEffect(() => {
@@ -31,6 +35,7 @@ export function AppRouter() {
     return (
         <BrowserRouter>
             <MatomoTracker />
+            <Suspense fallback={<div className="route-loading" aria-busy="true" aria-label="Chargement" />}>
             <Routes>
                 <Route
                     path="/"
@@ -163,6 +168,7 @@ export function AppRouter() {
                     element={<AdminRedirect />}
                 />
             </Routes>
+            </Suspense>
             <CookieBanner />
         </BrowserRouter>
     );

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -149,3 +149,9 @@ select {
   height: 100%;
   width: 100%;
 }
+
+/* Espace reserve pendant le chargement differe d'une page (Suspense), pour
+   limiter le saut de mise en page avant l'affichage du contenu. */
+.route-loading {
+  min-height: 60vh;
+}


### PR DESCRIPTION
## Contexte
Suite de l'optimisation des performances (score Lighthouse deja passe de ~45 a 85 apres l'optimisation des images). Cette PR traite les 4 axes restants, **par ordre d'importance**.

## 1. Decoupage du JavaScript (impact principal)
- **Chargement differe de toutes les pages** via `React.lazy` + `Suspense` : chaque page devient un fichier JS separe, telecharge uniquement quand l'utilisateur visite la route. Le bundle initial de l'accueil est nettement allege.
- **Carte Leaflet differee** : la carte « Nous trouver » (sous la ligne de flottaison) et sa dependance Leaflet (**167 ko / 50 ko gzip**) ne sont plus chargees au premier rendu — elles arrivent a la demande.
- **Icones de marqueur servies localement** (bundlees par Vite) au lieu de `unpkg.com` : deux requetes vers un domaine externe en moins.

Repartition apres build : chaque route fait 1 a 6 ko gzip, et le gros morceau (Leaflet) est isole hors du chemin critique.

## 2. Polices — rien a faire
Le site utilise **uniquement des polices systeme** (`system-ui, 'Segoe UI', Roboto`). Aucune police n'est telechargee : c'est deja optimal (pas de `@font-face`, donc `font-display`/preload sans objet).

## 3. Ressources bloquantes
Le principal CSS bloquant etait celui de **Leaflet (6 ko gzip)** : il est desormais un fichier separe charge avec la carte. L'`index.css` restant ne fait que **~5 ko gzip** (negligeable) — pas de sur-ingenierie d'extraction de CSS critique pour si peu.

## 4. Cache navigateur
Nouveau `frontend/public/.htaccess` (copie tel quel dans `dist/` au build) :
- **cache long et immuable** (1 an) pour les assets hashes (js/css/images/polices) ;
- **revalidation** d'`index.html` pour recuperer chaque deploiement immediatement ;
- cache court pour `robots.txt`/`sitemap.xml` ;
- **compression** gzip des ressources texte ;
- **routage SPA** (fallback vers `index.html`).

## Verification
- `tsc --noEmit` : OK · ESLint : OK
- `vite build` : OK (chunks separes par route + Leaflet isole ; `.htaccess` bien copie dans `dist/`).

## Note deploiement
Le `.htaccess` doit se trouver a la racine du domaine du front. Avec un build Vite standard, il arrive automatiquement dans `dist/` — rien de manuel si le deploiement envoie le contenu de `dist/`.