### PR TITLE
perf(front): accelerer le LCP (accueil eager + preconnect API)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,6 +7,11 @@
 
   <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
 
+  <!-- Ouvre au plus tot la connexion (DNS + TLS) vers l'API, qui sert aussi les
+       images : la banniere d'accueil (element LCP) se telecharge plus vite. -->
+  <link rel="preconnect" href="%VITE_API_URL%" />
+  <link rel="dns-prefetch" href="%VITE_API_URL%" />
+
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 </head>
 

--- a/frontend/src/router/AppRouter.tsx
+++ b/frontend/src/router/AppRouter.tsx
@@ -3,18 +3,22 @@ import { BrowserRouter, Route, Routes } from "react-router-dom";
 import { MainLayout } from "../layouts/MainLayout";
 import { CookieBanner } from "../components/cookies/CookieBanner";
 import { MatomoTracker } from "../components/analytics/MatomoTracker";
+import { HomePage } from "../pages/HomePage";
+// ErrorPage est deja inclus dans le bundle initial (importe par plusieurs pages
+// comme composant de repli) : un chargement differe serait sans effet.
+import { ErrorPage } from "../pages/ErrorPage";
 
-// Chargement differe des pages : chaque page devient un fichier JS separe,
-// telecharge uniquement lorsque l'utilisateur visite la route correspondante.
-// Le bundle initial (page d'accueil) s'en trouve nettement allege.
-const HomePage = lazy(() => import("../pages/HomePage").then((m) => ({ default: m.HomePage })));
+// La page d'accueil est chargee immediatement (import statique) : c'est la
+// route la plus visitee et l'entree principale, un chargement differe y
+// ajouterait un aller-retour reseau avant le premier rendu (au detriment du
+// FCP/LCP). Les autres pages restent en chargement differe : chacune devient
+// un fichier JS separe, telecharge uniquement lorsqu'on visite sa route.
 const DisciplinePage = lazy(() => import("../pages/DisciplinePage").then((m) => ({ default: m.DisciplinePage })));
 const NotFoundPage = lazy(() => import("../pages/NotFoundPage").then((m) => ({ default: m.NotFoundPage })));
 const PostPage = lazy(() => import("../pages/PostPage").then((m) => ({ default: m.PostPage })));
 const ClubPostsPage = lazy(() => import("../pages/ClubPostsPage").then((m) => ({ default: m.ClubPostsPage })));
 const CalendarPage = lazy(() => import("../pages/CalendarPage").then((m) => ({ default: m.CalendarPage })));
 const ContactPage = lazy(() => import("../pages/ContactPage").then((m) => ({ default: m.ContactPage })));
-const ErrorPage = lazy(() => import("../pages/ErrorPage").then((m) => ({ default: m.ErrorPage })));
 const CGUPage = lazy(() => import("../pages/CGUPage").then((m) => ({ default: m.CGUPage })));
 const MentionsPage = lazy(() => import("../pages/MentionsLegales").then((m) => ({ default: m.MentionsPage })));
 const PolitiqueConfidentialitePage = lazy(() => import("../pages/PolitiqueConfidentialite").then((m) => ({ default: m.PolitiqueConfidentialitePage })));


### PR DESCRIPTION
## Diagnostic (rapport Lighthouse)
- TBT 130 ms et CLS 0,079 : **verts** (JS et stabilite visuelle OK).
- **FCP 2,2 s et LCP 3,4 s : oranges** — c'est le plafond du score.

La banniere d'accueil (element LCP) etait piegee dans une **cascade** :
`index.html -> JS -> montage React -> appel API -> URL de la banniere -> telechargement`.
Elle ne pouvait pas commencer a charger avant la fin de l'aller-retour API.

## Corrections
1. **Page d'accueil en import statique** (retour arriere sur le lazy-loading introduit en #100 pour *cette* route). La HomePage est l'entree principale et la page testee : la charger a la demande ajoutait un aller-retour reseau avant le premier rendu. Elle rejoint le bundle initial (+~2 ko gzip), les **autres routes restent en chargement differe**.
2. **`preconnect` + `dns-prefetch` vers le domaine API** dans `index.html` (via `%VITE_API_URL%`, donc adapte a chaque environnement). L'API sert aussi les images : ouvrir la connexion DNS+TLS au plus tot fait arriver la banniere plus vite.
3. **ErrorPage en import statique** : deja present dans le bundle initial (importe comme repli par plusieurs pages), son `lazy` etait sans effet (avertissement de build supprime).

## Ce qui n'est PAS le probleme (verifie)
- **Polices** : systeme, rien a telecharger.
- **Cache images API** : le `public/.htaccess` cache deja les images 1 an (`ExpiresByType image/*`).
- **Matomo** : `VITE_MATOMO_URL` vide sur le test — aucun script tiers.

## Verification
`tsc` OK · ESLint OK · `vite build` OK (HomePage fusionnee au bundle principal, Leaflet toujours isole/differe, plus d'avertissement d'import).

## Piste suivante (si besoin de gratter encore)
« Improve image delivery 62 KiB » : la banniere (max 2000 px) est surdimensionnee pour mobile. Un jeu d'images responsives (`srcset`) reduirait encore le LCP mobile — plus lourd a mettre en place (variantes cote API), a faire seulement si l'objectif 90+ n'est pas atteint.