### PR TITLE
fix(front): bonnes pratiques (cookie tiers, ratio banniere, iframe)

### DIFF
--- a/app/Http/Resources/SiteSettingsResource.php
+++ b/app/Http/Resources/SiteSettingsResource.php
@@ -4,6 +4,7 @@ namespace App\Http\Resources;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Facades\Storage;
 
 class SiteSettingsResource extends JsonResource
 {
@@ -14,12 +15,19 @@ class SiteSettingsResource extends JsonResource
      */
     public function toArray(Request $request): array
     {
+        [$bannW, $bannH] = $this->imageDimensions($this->banniere);
+
         return [
             'id' => $this->id,
             'logo' => $this->logo,
-            'logo_url' => $this->logo ? asset('storage/' . $this->logo) : null,
+            'logo_url' => $this->logo ? asset('storage/'.$this->logo) : null,
             'banniere' => $this->banniere,
-            'banniere_url' => $this->banniere ? asset('storage/' . $this->banniere) : null,
+            'banniere_url' => $this->banniere ? asset('storage/'.$this->banniere) : null,
+            // Dimensions reelles de la banniere : permettent au front de reserver
+            // le bon espace (element LCP) sans deformer l'image ni provoquer de
+            // decalage de mise en page.
+            'banniere_width' => $bannW,
+            'banniere_height' => $bannH,
             'adresse' => $this->adresse,
             'telephone' => $this->telephone,
             'email' => $this->email,
@@ -29,5 +37,29 @@ class SiteSettingsResource extends JsonResource
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
         ];
+    }
+
+    /**
+     * Dimensions (largeur, hauteur) d'une image stockee sur le disque public.
+     * Retourne [null, null] si le chemin est vide ou le fichier introuvable.
+     * L'appel n'a lieu qu'au (re)calcul de la reponse publique, elle-meme mise
+     * en cache.
+     *
+     * @return array{0: int|null, 1: int|null}
+     */
+    private function imageDimensions(?string $path): array
+    {
+        if (! $path) {
+            return [null, null];
+        }
+
+        $full = Storage::disk('public')->path($path);
+        if (! is_file($full)) {
+            return [null, null];
+        }
+
+        $size = @getimagesize($full);
+
+        return $size ? [(int) $size[0], (int) $size[1]] : [null, null];
     }
 }

--- a/frontend/src/components/club/ClubPostCard.tsx
+++ b/frontend/src/components/club/ClubPostCard.tsx
@@ -33,7 +33,9 @@ function getYouTubeEmbedUrl(url: string) {
         return null;
     }
 
-    return `https://www.youtube.com/embed/${youtubeId}`;
+    // Domaine « no-cookie » : YouTube ne depose pas de cookie tiers tant que la
+    // video n'est pas lue (respect du consentement, meilleures bonnes pratiques).
+    return `https://www.youtube-nocookie.com/embed/${youtubeId}`;
 }
 
 export default function ClubPostCard({

--- a/frontend/src/components/layout/DesktopFooter.tsx
+++ b/frontend/src/components/layout/DesktopFooter.tsx
@@ -29,8 +29,6 @@ export function DesktopFooter({ logoUrl }: Props) {
                                 src={logoUrl}
                                 alt="BCJ37 - Billard Club de Joué-lès-Tours"
                                 className="site-logo__image"
-                                width={706}
-                                height={349}
                                 loading="lazy"
                                 decoding="async"
                             />

--- a/frontend/src/components/layout/DesktopNavigation.tsx
+++ b/frontend/src/components/layout/DesktopNavigation.tsx
@@ -28,8 +28,6 @@ export function DesktopNavigation({ menus, logoUrl }: Props) {
                             src={logoUrl}
                             alt="BCJ37 - Billard Club de Joué-lès-Tours"
                             className="site-logo-desktop site-logo__image"
-                            width={706}
-                            height={349}
                             decoding="async"
                         />
                     ) : (

--- a/frontend/src/components/layout/MobileFooter.tsx
+++ b/frontend/src/components/layout/MobileFooter.tsx
@@ -28,8 +28,6 @@ export function MobileFooter({ logoUrl }: Props) {
                                 src={logoUrl}
                                 alt="BCJ37 - Billard Club de Joué-lès-Tours"
                                 className="site-logo__image"
-                                width={706}
-                                height={349}
                                 loading="lazy"
                                 decoding="async"
                             />

--- a/frontend/src/components/layout/MobileNavigation.tsx
+++ b/frontend/src/components/layout/MobileNavigation.tsx
@@ -102,8 +102,6 @@ export function MobileNavigation({ logoUrl }: Props) {
                                 src={logoUrl}
                                 alt="BCJ37 - Billard Club de Joué-lès-Tours"
                                 className="site-logo__image"
-                                width={706}
-                                height={349}
                                 decoding="async"
                             />
                         ) : (

--- a/frontend/src/pages/CalendarPage.tsx
+++ b/frontend/src/pages/CalendarPage.tsx
@@ -48,7 +48,7 @@ export function CalendarPage() {
                             title="Agenda du Billard Club de Joué-lès-Tours - vue semaine"
                             width="100%"
                             height="800"
-                            frameBorder="0"
+                            style={{ border: 0 }}
                             scrolling="no"
                             onError={() => setIframeError(true)}
                         />

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -53,8 +53,8 @@ export function HomePage() {
                     src={home.site_settings.banniere_url}
                     alt="Bienvenue au BCJ37"
                     className="hero-banner"
-                    width={3222}
-                    height={964}
+                    width={home.site_settings.banniere_width ?? undefined}
+                    height={home.site_settings.banniere_height ?? undefined}
                     fetchPriority="high"
                     decoding="async"
                 />
@@ -102,7 +102,7 @@ export function HomePage() {
                                         height="600"
                                         src={home.featured_post.video_url}
                                         title={home.featured_post.title ?? home.featured_post.titre}
-                                        frameBorder="0"
+                                        style={{ border: 0 }}
                                         allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
                                         allowFullScreen
                                     />

--- a/frontend/src/pages/PostPage.tsx
+++ b/frontend/src/pages/PostPage.tsx
@@ -177,7 +177,7 @@ export function PostPage() {
                                 height="600"
                                 src={post.video_url}
                                 title={postTitle}
-                                frameBorder="0"
+                                style={{ border: 0 }}
                                 allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
                                 allowFullScreen
                             />

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -28,6 +28,8 @@ export type SiteSettings = {
     logo_url?: string | null;
     banniere?: string | null;
     banniere_url?: string | null;
+    banniere_width?: number | null;
+    banniere_height?: number | null;
     adresse?: string | null;
     telephone?: string | null;
     email?: string | null;


### PR DESCRIPTION
## Contexte
Le rapport PageSpeed Insights donne **Performance 92 / Accessibilite 100 / SEO 100**, mais **Bonnes pratiques a 69**. Cette PR corrige les items identifiables avec certitude.

## Corrections
### 1. Cookie tiers (« Utilise des cookies tiers — 1 cookie »)
L'embed YouTube utilisait `youtube.com/embed`, qui depose un cookie tiers des le chargement. Passe a **`youtube-nocookie.com/embed`** : plus de cookie tant que la video n'est pas lue. Coherent avec le bandeau de consentement.

### 2. « Images affichees dans un format incorrect » — la banniere
La banniere d'accueil portait des dimensions **codees en dur erronees** (3222×964, introduites lors de l'optimisation LCP) alors que l'image reelle fait **2000×217**. Combine a `width:100%`, cela la rendait **~3× trop haute et recadree** (bug visuel) en plus de declencher l'audit.
- L'API expose desormais les **dimensions reelles** (`banniere_width` / `banniere_height`, via `getimagesize` sur le fichier — appel amorti par le cache de la reponse publique).
- Le front les utilise : espace correctement reserve (bon pour le CLS), aucune deformation.
- **Logos** : dimensions codees en dur (inexactes elles aussi) retirees. Leur rendu est deja fige par le CSS (`height:60px; width:auto`), donc aucun changement visuel ni deformation — et l'audit ne les signalait pas.

### 3. Attribut deprecie (panneau Issues)
`frameBorder` (deprecie) remplace par `style={{ border: 0 }}` sur les 3 iframes concernees (accueil, article, calendrier).

## Ce qui reste (besoin d'info)
- **« Erreurs navigateur enregistrees dans la console »** : je ne vois pas les messages. Si tu deplies cet audit et me donnes le texte des erreurs, je les corrige.
- `scrolling="no"` (calendrier Google) est aussi deprecie mais son retrait modifierait le comportement de defilement du calendrier : laisse volontairement.

## Verification
- `tsc` OK · ESLint OK · `vite build` OK
- Suite backend : **203 passed** (3085 assertions).