### PR TITLE
chore(front): separer les configs test/prod et deriver l'URL admin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .env
 .env.backup
 .env.production
+.env.test
 .phpunit.result.cache
 Homestead.json
 Homestead.yaml

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "build:test": "tsc -b && vite build --mode test",
     "lint": "eslint .",
     "preview": "vite preview"
   },

--- a/frontend/src/router/AppRouter.tsx
+++ b/frontend/src/router/AppRouter.tsx
@@ -29,7 +29,11 @@ const DisciplinePostsPage = lazy(() => import("../components/discipline/Discipli
 
 export function AdminRedirect() {
     useEffect(() => {
-        window.location.replace("https://api.test.alexandrebourlier.fr/admin");
+        // L'admin (OpenAdmin) est servi par l'API, sous /admin. On derive l'URL
+        // du domaine de l'API (VITE_API_URL) : plus aucune URL codee en dur a
+        // changer d'un environnement a l'autre (test / production).
+        const adminUrl = new URL(import.meta.env.VITE_API_URL).origin + "/admin";
+        window.location.replace(adminUrl);
     }, []);
 
     return null;


### PR DESCRIPTION
## Objectif
Preparer la bascule vers la production (`bcj37.fr`) **sans casser le serveur de test**. Jusqu'ici, `.env.production` contenait les valeurs du **test**, donc migrer vers la prod aurait empeche de rebuild le test.

## Changements (versionnes)
- **Script `build:test`** : `vite build --mode test`. Desormais :
  - `npm run build:test` → build **test** (`.env.test`) — utilise par `deploy/deploy.ps1`.
  - `npm run build` → build **prod bcj37** (`.env.production`).
  - Les deux environnements coexistent, aucun ne perturbe l'autre.
- **URL de l'admin derivee de `VITE_API_URL`** dans `AdminRedirect` : fin de l'URL codee en dur (`api.test.alexandrebourlier.fr/admin`). Elle s'adapte automatiquement au build (test ou prod) — plus rien a modifier a la main.
- **`.env.test`** ajoute au `.gitignore` (comme `.env` / `.env.production`).

## Fichiers de config (locaux, non versionnes)
Crees/mis a jour en local (gitignores) :
- `frontend/.env.test` → valeurs du **test**.
- `frontend/.env.production` → valeurs **prod bcj37** (+ Matomo active).
- `deploy/deploy.ps1` → build via `build:test`.
- `deploy/MIGRATION-PROD-bcj37.md` → checklist complete de bascule.

## Verification
- Build **test** : le bundle embarque `api.test.alexandrebourlier.fr` + preconnect test. ✅
- Build **prod** : le bundle embarque `api.bcj37.fr` + `analytics.bcj37.fr` + preconnect prod. ✅
- `tsc` OK · ESLint OK.