### PR TITLE
fix(securite): proteger les endpoints exposant des donnees personnelles

### DIFF
--- a/frontend/src/api/contactApi.ts
+++ b/frontend/src/api/contactApi.ts
@@ -1,9 +1,5 @@
-import { apiGet, apiPost } from "./client";
-import type { ApiResponse, Contact, ContactFormPayload } from "../types/api";
-
-export function getContacts() {
-    return apiGet<ApiResponse<Contact[]>>("/contact");
-}
+import { apiPost } from "./client";
+import type { ApiResponse, ContactFormPayload } from "../types/api";
 
 export function sendContact(payload: ContactFormPayload) {
     return apiPost<ApiResponse<{ message: string }>>("/contact", payload);

--- a/frontend/src/components/contact/Contact.tsx
+++ b/frontend/src/components/contact/Contact.tsx
@@ -1,65 +1,12 @@
-import { useEffect, useState } from "react";
-import { getContacts } from "../../api/contactApi";
-import { ApiError } from "../../api/client";
 import ContactInfos from "./ContactInfos";
-import AlertToast from "../ui/AlertToast";
 
+// La page de contact affiche les coordonnées du club et le formulaire.
+// Elle ne récupère plus la liste des messages reçus (donnée privée, réservée à
+// l'administration) : le formulaire est désormais toujours affiché.
 export default function Contact() {
-    const [introMessage, setIntroMessage] = useState<string | null>(null);
-    const [loading, setLoading] = useState(true);
-    const [error, setError] = useState<string | null>(null);
-
-    useEffect(() => {
-        let isMounted = true;
-
-        getContacts()
-            .then((response) => {
-                if (!isMounted) return;
-
-                setIntroMessage(response.data[0]?.message ?? null);
-            })
-            .catch((error) => {
-                if (!isMounted) return;
-
-                console.error(error);
-
-                if (error instanceof ApiError && error.status >= 500) {
-                    setError(
-                        "Les informations de contact ne peuvent pas être chargées pour le moment."
-                    );
-                    return;
-                }
-
-                setError(
-                    "Une erreur est survenue pendant le chargement des informations de contact."
-                );
-            })
-            .finally(() => {
-                if (!isMounted) return;
-
-                setLoading(false);
-            });
-
-        return () => {
-            isMounted = false;
-        };
-    }, []);
-
-    if (loading) {
-        return <p>Chargement...</p>;
-    }
-
     return (
         <section className="contact-page">
-            {error && (
-                <AlertToast
-                    message={error}
-                    type="error"
-                    onClose={() => setError(null)}
-                />
-            )}
-
-            <ContactInfos introMessage={introMessage} />
+            <ContactInfos />
         </section>
     );
 }

--- a/frontend/src/components/contact/ContactInfos.tsx
+++ b/frontend/src/components/contact/ContactInfos.tsx
@@ -3,23 +3,21 @@ import { ArticleTitle } from "../ui/Title";
 import ContactForm from "./ContactForm";
 
 type ContactInfosProps = {
-    introMessage: string | null;
+    introMessage?: string | null;
 };
 
 export default function ContactInfos({
-    introMessage,
+    introMessage = null,
 }: ContactInfosProps) {
-    if (!introMessage) {
-        return null;
-    }
-
     return (
         <div>
             <ArticleTitle>Contact</ArticleTitle>
             <ArticleCard className="contact-intro">
-                <p style={{ whiteSpace: "pre-line" }}>
-                    {introMessage}
-                </p>
+                {introMessage && (
+                    <p style={{ whiteSpace: "pre-line" }}>
+                        {introMessage}
+                    </p>
+                )}
                 <ContactForm/>
             </ArticleCard>
         </div>

--- a/routes/api.php
+++ b/routes/api.php
@@ -67,8 +67,12 @@ Route::prefix('v1')->group(function () {
     });
     
     
-    Route::get('/licencies', [LicenciesController::class, 'index']);
-    Route::get('/licencies/search/{name}', [LicenciesController::class, 'searchByName']);
+    // Licenciés : données personnelles (RGPD) → réservé à l'administration
+    // authentifiée (pas d'exposition publique du fichier des adhérents).
+    Route::middleware(['web', 'admin.api'])->group(function () {
+        Route::get('/licencies', [LicenciesController::class, 'index']);
+        Route::get('/licencies/search/{name}', [LicenciesController::class, 'searchByName']);
+    });
 
     // Routes batches
     Route::middleware(['web', 'admin.api'])->group(function () {
@@ -106,7 +110,11 @@ Route::prefix('v1')->group(function () {
 
     // Routes pour les contacts
     Route::prefix('/contact')->group(function () {
-        Route::get('/', [ContactController::class, 'index']);
+        // Liste des messages reçus : données personnelles → réservé à
+        // l'administration authentifiée.
+        Route::get('/', [ContactController::class, 'index'])
+            ->middleware(['web', 'admin.api']);
+        // Envoi public d'un message depuis le formulaire (débit limité).
         Route::post('/', [ContactController::class, 'send'])
             ->middleware('throttle:5,1');
     });


### PR DESCRIPTION
## Failles corrigees (audit de securite)

Deux routes API renvoyaient des **donnees personnelles sans authentification** :

### 🔴 GET /api/v1/contact
Renvoyait `Contact::all()` — **tous les messages du formulaire** (nom, email, telephone, contenu) a n'importe qui. Pire : la page de contact publique recuperait ces messages et **affichait le message d'un visiteur** comme texte d'introduction.

### 🔴 GET /api/v1/licencies (+ /search/{name})
Exposait le **fichier complet des adherents** (licence, nom, prenom) sans auth — donnee personnelle (RGPD).

## Correctifs
- Les deux GET passent derriere l'**authentification admin** (`middleware(['web','admin.api'])`), comme les routes d'import de licences.
- Le **POST /contact** (envoi d'un message) **reste public** et limite en debit (`throttle:5,1`).
- **Front** : la page de contact n'appelle plus `getContacts`. Le formulaire est desormais **toujours affiche** — il etait auparavant conditionne a la presence d'un message en base (`ContactInfos` renvoyait `null` sinon). Retrait du code mort `getContacts`.

## Verification
- Test dedie : GET /contact, /licencies, /search ne renvoient plus 200 sans auth ; POST /contact reste public (422).
- Aucun test existant ne dependait de l'exposition.
- Suite complete : **203 passed** · Front : `tsc` / ESLint / `vite build` OK.

## Note
Si le club souhaite un texte d'introduction configurable sur la page de contact (l'ancien mecanisme detourne), il faudra l'ajouter proprement (ex : champ dans les parametres du site). A voir si besoin.