### PR TITLE
feat(contact): rendre le destinataire du formulaire configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,13 @@ MAIL_ENCRYPTION=null
 MAIL_FROM_ADDRESS="contact@bcj37.fr"
 MAIL_FROM_NAME="${APP_NAME}"
 
+# Formulaire de contact : destinataire et expediteur (defaut = production).
+# Sur un environnement de test, rediriger vers une boite perso, ex :
+# CONTACT_TO_ADDRESS=adresse@exemple.fr
+CONTACT_TO_ADDRESS="contact@bcj37.fr"
+CONTACT_FROM_ADDRESS="no-reply@bcj37.fr"
+CONTACT_FROM_NAME="BCJ37 — Formulaire de contact"
+
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 AWS_DEFAULT_REGION=us-east-1

--- a/app/Http/Controllers/Api/ContactController.php
+++ b/app/Http/Controllers/Api/ContactController.php
@@ -96,12 +96,12 @@ class ContactController extends Controller
 
         try {
             Mail::raw(
-                "Nom : {$validated['name']}\n" .
-                "Email : {$validated['email']}\n\n" .
+                "Nom : {$validated['name']}\n".
+                "Email : {$validated['email']}\n\n".
                 "Message :\n{$validated['message']}",
                 function ($message) use ($validated) {
-                    $message->from('no-reply@bcj37.fr', 'BCJ37 — Formulaire de contact');
-                    $message->to('contact@bcj37.fr');
+                    $message->from(config('mail.contact.from'), config('mail.contact.from_name'));
+                    $message->to(config('mail.contact.to'));
                     $message->replyTo($validated['email'], $validated['name']);
                     $message->subject('Nouveau message depuis le formulaire de contact');
                 }

--- a/config/mail.php
+++ b/config/mail.php
@@ -131,4 +131,22 @@ return [
         ],
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Formulaire de contact
+    |--------------------------------------------------------------------------
+    |
+    | Adresses utilisees par le formulaire de contact public : destinataire des
+    | messages recus et expediteur affiche. Pilotables par environnement (ex.
+    | rediriger vers une boite de test) sans modifier le code. Valeurs par
+    | defaut = production.
+    |
+    */
+
+    'contact' => [
+        'to' => env('CONTACT_TO_ADDRESS', 'contact@bcj37.fr'),
+        'from' => env('CONTACT_FROM_ADDRESS', 'no-reply@bcj37.fr'),
+        'from_name' => env('CONTACT_FROM_NAME', 'BCJ37 — Formulaire de contact'),
+    ],
+
 ];

--- a/tests/Feature/ContactRecipientTest.php
+++ b/tests/Feature/ContactRecipientTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+
+class ContactRecipientTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_le_destinataire_par_defaut_est_l_adresse_de_production(): void
+    {
+        $this->assertSame('contact@bcj37.fr', config('mail.contact.to'));
+        $this->assertSame('no-reply@bcj37.fr', config('mail.contact.from'));
+    }
+
+    public function test_le_formulaire_envoie_vers_l_adresse_configuree(): void
+    {
+        // Simule un environnement (ex. test) qui redirige les messages.
+        config([
+            'mail.default' => 'array',
+            'mail.contact.to' => 'boite-de-test@exemple.fr',
+        ]);
+
+        $this->postJson('/api/v1/contact', [
+            'name' => 'Jean Dupont',
+            'email' => 'visiteur@exemple.fr',
+            'message' => 'Bonjour, ceci est un test.',
+        ])->assertStatus(200);
+
+        $messages = Mail::mailer()->getSymfonyTransport()->messages();
+        $this->assertCount(1, $messages);
+
+        $sent = $messages[0]->getOriginalMessage();
+        $this->assertSame('boite-de-test@exemple.fr', $sent->getTo()[0]->getAddress());
+        // L'email du visiteur reste en reply-to (pas en destinataire).
+        $this->assertSame('visiteur@exemple.fr', $sent->getReplyTo()[0]->getAddress());
+    }
+}


### PR DESCRIPTION
## Objectif
Le destinataire des messages du formulaire de contact etait code en dur (contact@bcj37.fr) dans le controleur. Il est desormais **pilote par la configuration**, pour pouvoir rediriger les messages sans toucher au code (ex. vers une boite perso sur le serveur de test).

## Changements
- **config/mail.php** : nouveau bloc `contact` (to / from / from_name), pilote par les variables `CONTACT_TO_ADDRESS`, `CONTACT_FROM_ADDRESS`, `CONTACT_FROM_NAME`. **Valeurs par defaut = production** (contact@bcj37.fr / no-reply@bcj37.fr).
- **ContactController** : lit ces valeurs au lieu des adresses en dur.
- **.env.example** : variables documentees.

## Utilisation
- **Production** : rien a faire, les defauts sont deja les bonnes adresses.
- **Test** : ajouter `CONTACT_TO_ADDRESS=alexandre@bourlier.email` dans le `.env` du serveur de test.

## Tests
- 2 tests dedies (destinataire par defaut = prod ; le formulaire envoie vers l'adresse configuree, l'email du visiteur restant en reply-to).
- Suite complete : **205 passed**.
