### PR TITLE
chore: rendre le projet installable et lancable (seeders, admin, env, README)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,10 @@ APP_DEBUG=true
 APP_URL=http://localhost:8000
 ADMIN_HTTPS=false
 
+# URL du frontend React (dev). Utilisee pour le CORS (autorise les requetes du
+# front) et pour construire des liens vers le site public.
+FRONTEND_URL=http://localhost:5173
+
 LOG_CHANNEL=stack
 LOG_DEPRECATIONS_CHANNEL=null
 LOG_LEVEL=debug

--- a/README.md
+++ b/README.md
@@ -373,18 +373,41 @@ Documentation générée avec Scribe.
 
 # Installation
 
-## Backend Laravel
+Le projet est en **deux parties** : une API Laravel (back-office + API) et un
+frontend React (site public). Il faut lancer les deux.
+
+**Prerequis** : PHP 8.2+, Composer, Node.js 18+, une base MySQL (ou SQLite).
+
+## Backend Laravel (API + administration)
 ```bash
 composer install
 cp .env.example .env
 php artisan key:generate
-php artisan migrate
+
+# Renseigner la base dans .env (DB_DATABASE, DB_USERNAME, DB_PASSWORD...),
+# creer la base correspondante, puis :
+php artisan migrate --seed      # tables + donnees de demonstration + compte admin
+php artisan storage:link        # sert les fichiers/images televerses
+
+php artisan serve               # API disponible sur http://localhost:8000
 ```
-## Frontend React
+
+Le seeding cree du contenu de demonstration (articles, documents) et un compte
+d'administration :
+
+* Administration : http://localhost:8000/admin
+* Identifiants : **admin** / **password** (evaluation locale ; a changer en production)
+
+## Frontend React (site public)
 ```bash
+cd frontend
 npm install
-npm run dev
+cp .env.example .env            # definit VITE_API_URL = http://localhost:8000/api/v1
+npm run dev                     # site public sur http://localhost:5173
 ```
+
+> Le `.env` du front doit pointer vers l'API (`VITE_API_URL`), et l'API doit
+> autoriser l'origine du front (`FRONTEND_URL` dans le `.env` du back).
 ---
 
 # Déploiement

--- a/database/seeders/AdminUserSeeder.php
+++ b/database/seeders/AdminUserSeeder.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+
+/**
+ * Compte administrateur de demonstration pour l'administration OpenAdmin.
+ *
+ * Identifiants (evaluation locale uniquement) : admin / password.
+ * A supprimer ou changer avant toute mise en production.
+ */
+class AdminUserSeeder extends Seeder
+{
+    public function run(): void
+    {
+        if (DB::table('admin_users')->where('username', 'admin')->exists()) {
+            return;
+        }
+
+        $userId = DB::table('admin_users')->insertGetId([
+            'username' => 'admin',
+            'password' => Hash::make('password'),
+            'name' => 'Administrateur',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        // Rattache au role « Administrateur du site » (admin_site).
+        $roleId = DB::table('admin_roles')->where('slug', 'admin_site')->value('id');
+        if ($roleId !== null) {
+            DB::table('admin_role_users')->insert([
+                'role_id' => $roleId,
+                'user_id' => $userId,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -20,6 +20,15 @@ class DatabaseSeeder extends Seeder
         // ]);
 
         $this->call([
+            // Compte d'administration + reglages du site.
+            AdminUserSeeder::class,
+            SiteSettingSeeder::class,
+            // Contenu de demonstration.
+            PostSeeder::class,
+            DocumentSeeder::class,
+            IndexSeeder::class,
+            // En dernier : recuperation de calendriers via un service externe
+            // (plus lent, necessite un acces reseau).
             CalendarSeeder::class,
         ]);
     }

--- a/database/seeders/SiteSettingSeeder.php
+++ b/database/seeders/SiteSettingSeeder.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Reglages minimaux du site (coordonnees) pour que la page d'accueil ne soit
+ * pas vide a la premiere installation. A completer ensuite via l'administration.
+ */
+class SiteSettingSeeder extends Seeder
+{
+    public function run(): void
+    {
+        if (DB::table('site_settings')->exists()) {
+            return;
+        }
+
+        DB::table('site_settings')->insert([
+            'telephone' => '02 47 00 00 00',
+            'email' => 'contact@bcj37.fr',
+            'adresse' => 'Joue-les-Tours (37300)',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+}

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,8 @@
+# URL de l'API Laravel consommee par le front (inclut le prefixe /api/v1).
+# En developpement, garder le meme hote que le back (localhost) pour l'auth par
+# cookie de session.
+VITE_API_URL=http://localhost:8000/api/v1
+
+# Suivi Matomo (optionnel : laisser vide pour desactiver).
+VITE_MATOMO_URL=
+VITE_MATOMO_SITE_ID=


### PR DESCRIPTION
Corrige les points bloquant l'execution du projet a partir d'un clone vierge :

- migrate --seed cree desormais du contenu de demo (articles, documents), un compte admin (admin / password) et les reglages du site.
- Ajout de frontend/.env.example (VITE_API_URL) et de FRONTEND_URL dans .env.example (CORS).
- README complete : base de donnees, migrate --seed, storage:link, identifiants admin, configuration et lancement du frontend.

Teste a froid sur un clone vierge (SQLite) : migrations OK, seeding OK, API sert les donnees, admin fonctionnel.